### PR TITLE
Add the Configuration Parameter include_index

### DIFF
--- a/docsrc/source/pages/config_general.csv
+++ b/docsrc/source/pages/config_general.csv
@@ -2,3 +2,4 @@ Parameter,Type,Default,Description
 ``title``,string,"Pandas Profiling Report","Title for the report, shown in the header and title bar."
 ``pool_size``,integer,0,"Number of workers in thread pool. When set to zero, it is set to the number of CPUs available."
 ``progress_bar``,boolean,True,"If True, `pandas-profiling` will display a progress bar."
+``include_index``,boolean,True,"If False, do not include the index column in the report."

--- a/src/pandas_profiling/config.py
+++ b/src/pandas_profiling/config.py
@@ -246,6 +246,7 @@ class Settings(BaseSettings):
     dataset: Dataset = Dataset()
     variables: Variables = Variables()
     infer_dtypes: bool = True
+    include_index: bool = True
 
     # Show the description at each variable (in addition to the overview tab)
     show_variable_description: bool = True

--- a/src/pandas_profiling/model/pandas/dataframe_pandas.py
+++ b/src/pandas_profiling/model/pandas/dataframe_pandas.py
@@ -18,7 +18,8 @@ def pandas_check_dataframe(df: pd.DataFrame) -> None:
 def pandas_preprocess(config: Settings, df: pd.DataFrame) -> pd.DataFrame:
     """Preprocess the dataframe
 
-    - Appends the index to the dataframe when it contains information
+    - Drops the index if `include_index` is False
+    - Otherwise, appends the index to the dataframe when it contains information
     - Rename the "index" column to "df_index", if exists
     - Convert the DataFrame's columns to str
 
@@ -29,8 +30,12 @@ def pandas_preprocess(config: Settings, df: pd.DataFrame) -> pd.DataFrame:
     Returns:
         The preprocessed DataFrame
     """
+    # Drop index if config specifies
+    if not config.include_index:
+        df = df.reset_index(drop=True)
+
     # Treat index as any other column
-    if (
+    elif (
         not pd.Index(np.arange(0, len(df))).equals(df.index)
         or df.index.dtype != np.int64
     ):

--- a/tests/unit/test_drop_index.py
+++ b/tests/unit/test_drop_index.py
@@ -1,0 +1,33 @@
+"""Tests the include_index argument."""
+import pandas as pd
+import json
+from pandas_profiling import ProfileReport
+
+INDEX_COL = 'b'
+
+df = pd.DataFrame({'a': [1, 2, 3], INDEX_COL: [10, 11, 12]})
+df = df.set_index(INDEX_COL)
+
+
+def test_drop_index_true_explicit():
+    """Confirm the index is dropped when include_index is set to True."""
+    profile = ProfileReport(df, include_index=True, progress_bar=False)
+    profile_dict = json.loads(profile.to_json())
+
+    assert INDEX_COL in profile_dict['variables'].keys()
+
+
+def test_drop_index_true_implicit():
+    """Confirm the index is dropped when include_index is not set."""
+    profile = ProfileReport(df, progress_bar=False)
+    profile_dict = json.loads(profile.to_json())
+
+    assert INDEX_COL in profile_dict['variables'].keys()
+
+
+def test_drop_index_false():
+    """Confirm the index is dropped when include_index is set to False."""
+    profile = ProfileReport(df, include_index=False, progress_bar=False)
+    profile_dict = json.loads(profile.to_json())
+
+    assert INDEX_COL not in profile_dict['variables'].keys()


### PR DESCRIPTION
Add the configuration parameter `include_index`. 

Default value is True. When True, the index column is included in the report. When False, it is excluded.