### PR TITLE
docs: fix typo in link

### DIFF
--- a/docsrc/source/pages/great_expectations_integration.rst
+++ b/docsrc/source/pages/great_expectations_integration.rst
@@ -70,7 +70,7 @@ You can also configure each feature individually in the function call:
         handler=handler,
     )
 
-See `the Great Expectations Examples <https://pandas-profiling.github.io/pandas-profiling/examples/master/features/great_expectations_example.html>`_ for complete examples.
+See `the Great Expectations Examples <https://github.com/pandas-profiling/pandas-profiling/blob/master/examples/features/great_expectations_example.py>`_ for complete examples.
 
 
 Included Expectation types


### PR DESCRIPTION
The current URL link results in an `404 - File Not Found` error.

This is because the filename has a `.html` extension instead of `.py`.

However, just correcting the extension will make the file downloadable which is not the desired outcome. So I have changed the full path so that the example code opens in github like other source examples.