### PR TITLE
feat: [under review] enable global persistance handler for spark

### DIFF
--- a/src/pandas_profiling/model/dataframe.py
+++ b/src/pandas_profiling/model/dataframe.py
@@ -13,3 +13,8 @@ def check_dataframe(df: Any) -> None:
 @multimethod
 def preprocess(config: Settings, df: Any) -> Any:
     return df
+
+
+@multimethod
+def cleanup(config: Settings, df: Any) -> Any:
+    return df

--- a/src/pandas_profiling/model/describe.py
+++ b/src/pandas_profiling/model/describe.py
@@ -13,7 +13,7 @@ from pandas_profiling.model.correlations import (
     calculate_correlation,
     get_active_correlations,
 )
-from pandas_profiling.model.dataframe import check_dataframe, preprocess
+from pandas_profiling.model.dataframe import check_dataframe, cleanup, preprocess
 from pandas_profiling.model.duplicates import get_duplicates
 from pandas_profiling.model.missing import get_missing_active, get_missing_diagram
 from pandas_profiling.model.pairwise import get_scatter_plot, get_scatter_tasks
@@ -190,6 +190,9 @@ def describe(
         pbar.set_postfix_str("Completed")
 
         date_end = datetime.utcnow()
+
+    # run cleanup function
+    _ = cleanup(config, df)
 
     analysis = {
         "title": config.title,

--- a/src/pandas_profiling/model/pandas/dataframe_pandas.py
+++ b/src/pandas_profiling/model/pandas/dataframe_pandas.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 
 from pandas_profiling.config import Settings
-from pandas_profiling.model.dataframe import check_dataframe, preprocess
+from pandas_profiling.model.dataframe import check_dataframe, cleanup, preprocess
 from pandas_profiling.utils.dataframe import rename_index
 
 
@@ -41,4 +41,9 @@ def pandas_preprocess(config: Settings, df: pd.DataFrame) -> pd.DataFrame:
 
     # Ensure that columns are strings
     df.columns = df.columns.astype("str")
+    return df
+
+
+@cleanup.register
+def pandas_cleanup(config: Settings, df: pd.DataFrame) -> pd.DataFrame:
     return df

--- a/src/pandas_profiling/model/spark/dataframe_spark.py
+++ b/src/pandas_profiling/model/spark/dataframe_spark.py
@@ -3,7 +3,8 @@ import warnings
 from pyspark.sql import DataFrame
 
 from pandas_profiling.config import Settings
-from pandas_profiling.model.dataframe import check_dataframe, preprocess
+from pandas_profiling.model.dataframe import check_dataframe, cleanup, preprocess
+from pandas_profiling.model.spark.persist import GlobalPersistHandler
 
 
 @check_dataframe.register
@@ -40,4 +41,12 @@ def spark_preprocess(config: Settings, df: DataFrame) -> DataFrame:
     #
     # # Ensure that columns are strings
     # df.columns = df.columns.astype("str")
+    return df
+
+
+@cleanup.register
+def spark_cleanup(config: Settings, df: DataFrame) -> DataFrame:
+
+    GlobalPersistHandler.unpersist_all()
+
     return df

--- a/src/pandas_profiling/model/spark/describe_counts_spark.py
+++ b/src/pandas_profiling/model/spark/describe_counts_spark.py
@@ -4,6 +4,7 @@ from pyspark.sql import DataFrame
 
 from pandas_profiling.config import Settings
 from pandas_profiling.model.schema import CountColumnResult
+from pandas_profiling.model.spark.persist import GlobalPersistHandler
 from pandas_profiling.model.summary_algorithms import describe_counts
 
 
@@ -22,11 +23,16 @@ def describe_counts_spark(
 
     result = CountColumnResult()
 
+    series_name = series.columns[0]
     value_counts = series.groupBy(series.columns).count()
-    value_counts = value_counts.sort("count", ascending=False)
-    value_counts_index_sorted = value_counts.sort(series.columns[0], ascending=True)
 
-    n_missing = value_counts.where(value_counts[series.columns[0]].isNull()).first()
+    # persist value counts
+    GlobalPersistHandler.persist(f"value_counts_{series_name}", value_counts)
+
+    value_counts = value_counts.sort("count", ascending=False)
+    value_counts_index_sorted = value_counts.sort(series_name, ascending=True)
+
+    n_missing = value_counts.where(value_counts[series_name].isNull()).first()
     if n_missing is None:
         n_missing = 0
     else:
@@ -46,12 +52,12 @@ def describe_counts_spark(
     # FIXME: reduce to top-n and bottom-n
     value_counts_index_sorted = (
         value_counts_index_sorted.toPandas()
-        .set_index(series.columns[0], drop=True)
+        .set_index(series_name, drop=True)
         .squeeze(axis="columns")
     )
 
     result.n_missing = n_missing
-    result.value_counts = value_counts.persist()
+    result.value_counts = value_counts
     result.values = value_counts_index_sorted
 
     return config, series, result

--- a/src/pandas_profiling/model/spark/persist.py
+++ b/src/pandas_profiling/model/spark/persist.py
@@ -1,0 +1,45 @@
+import warnings
+from typing import Any, Dict
+
+from pyspark.sql import DataFrame
+
+
+class PersistHandler:
+    def __init__(self) -> None:
+        self.persisted_spark_objects: Dict[str, Any] = {}
+
+    def persist(self, name: str, spark_object: DataFrame):
+        # persist object
+        try:
+            spark_object.persist()
+        except Exception as e:
+            warnings.warn(f"Unable to persist {spark_object} due to exception {e}")
+
+        # and track it
+        self.persisted_spark_objects[name] = spark_object
+
+    def unpersist(self, name: str):
+        if name in self.persisted_spark_objects:
+
+            spark_object = self.persisted_spark_objects[name]
+
+            # unpersist object
+            try:
+                spark_object.unpersist()
+            except Exception as e:
+                warnings.warn(
+                    f"Unable to unpersist {spark_object} due to exception {e}"
+                )
+
+            # then stop tracking it
+            self.persisted_spark_objects.pop(name)
+        else:
+            warnings.warn(f"{name} is not a persisted spark object")
+
+    def unpersist_all(self):
+        all_obj_keys = list(self.persisted_spark_objects.keys())
+        for key in all_obj_keys:
+            self.unpersist(key)
+
+
+GlobalPersistHandler = PersistHandler()

--- a/tests/backends/spark_backend/test_persist_spark.py
+++ b/tests/backends/spark_backend/test_persist_spark.py
@@ -1,0 +1,40 @@
+import pandas as pd
+import pytest
+from pyspark.sql.types import IntegerType, StringType, StructField, StructType
+
+from pandas_profiling.config import Settings
+from pandas_profiling.model.spark.persist import GlobalPersistHandler
+from pandas_profiling.model.spark.sample_spark import spark_get_sample
+
+
+# FIXME: Move to data
+@pytest.fixture()
+def df(spark_session):
+    data_pandas = pd.DataFrame(
+        {
+            "make": ["Jaguar", "MG", "MINI", "Rover", "Lotus"] * 50,
+            "registration": ["AB98ABCD", "BC99BCDF", "CD00CDE", "DE01DEF", "EF02EFG"]
+            * 50,
+            "year": [1998, 1999, 2000, 2001, 2002] * 50,
+        }
+    )
+    # Turn the data into a Spark DataFrame, self.spark comes from our PySparkTest base class
+    data_spark = spark_session.createDataFrame(data_pandas)
+    return data_spark
+
+
+def test_spark_persist(df):
+    GlobalPersistHandler.persist("df", df)
+
+    assert GlobalPersistHandler.persisted_spark_objects["df"] == df
+
+    GlobalPersistHandler.persist("df2", df)
+    GlobalPersistHandler.persist("df3", df)
+
+    GlobalPersistHandler.unpersist("df3")
+
+    assert len(GlobalPersistHandler.persisted_spark_objects) == 2
+
+    GlobalPersistHandler.unpersist_all()
+
+    assert len(GlobalPersistHandler.persisted_spark_objects) == 0

--- a/tests/backends/spark_backend/test_report_spark.py
+++ b/tests/backends/spark_backend/test_report_spark.py
@@ -20,5 +20,5 @@ def correlation_data_num(spark_session):
 def test_report_spark(correlation_data_num):
 
     a = ProfileReport(correlation_data_num)
-    
+
     a.to_file("test.html", silent=False)


### PR DESCRIPTION
This feature creates a GlobalPersistHandler that
handles all persist and unpersistence within
spark-profiling so that it is easy to clean up after
profiling and we can persist objects we want to
during processing