### PR TITLE
Fix & clean examples in docs and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,30 +58,23 @@ _Contents:_ **[Examples](#examples)** |
 
 ## Examples
 
-The following examples can give you an impression of what the package can do:
+The following example reports showcase the potentialities of the package across a wide range of dataset and data types:
 
-* [Census Income](https://pandas-profiling.ydata.ai/examples/master/census/census_report.html) (US Adult Census data relating income)
-* [NASA Meteorites](https://pandas-profiling.ydata.ai/examples/master/meteorites/meteorites_report.html) (comprehensive set of meteorite landings) [![Open In Colab](https://camo.githubusercontent.com/52feade06f2fecbf006889a904d221e6a730c194/68747470733a2f2f636f6c61622e72657365617263682e676f6f676c652e636f6d2f6173736574732f636f6c61622d62616467652e737667)](https://colab.research.google.com/github/pandas-profiling/pandas-profiling/blob/master/examples/meteorites/meteorites.ipynb) [![Binder](https://camo.githubusercontent.com/483bae47a175c24dfbfc57390edd8b6982ac5fb3/68747470733a2f2f6d7962696e6465722e6f72672f62616467655f6c6f676f2e737667)](https://mybinder.org/v2/gh/pandas-profiling/pandas-profiling/master?filepath=examples%2Fmeteorites%2Fmeteorites.ipynb)
-* [Titanic](https://pandas-profiling.ydata.ai/examples/master/titanic/titanic_report.html) (the "Wonderwall" of datasets) [![Open In Colab](https://camo.githubusercontent.com/52feade06f2fecbf006889a904d221e6a730c194/68747470733a2f2f636f6c61622e72657365617263682e676f6f676c652e636f6d2f6173736574732f636f6c61622d62616467652e737667)](https://colab.research.google.com/github/pandas-profiling/pandas-profiling/blob/master/examples/titanic/titanic.ipynb) [![Binder](https://camo.githubusercontent.com/483bae47a175c24dfbfc57390edd8b6982ac5fb3/68747470733a2f2f6d7962696e6465722e6f72672f62616467655f6c6f676f2e737667)](https://mybinder.org/v2/gh/pandas-profiling/pandas-profiling/master?filepath=examples%2Ftitanic%2Ftitanic.ipynb)
+* [Census Income](https://pandas-profiling.ydata.ai/examples/master/census/census_report.html) (US Adult Census data relating income with other demographic properties)
+* [NASA Meteorites](https://pandas-profiling.ydata.ai/examples/master/meteorites/meteorites_report.html) (comprehensive set of meteorite landing - object properties and locations) [![Open In Colab](https://camo.githubusercontent.com/52feade06f2fecbf006889a904d221e6a730c194/68747470733a2f2f636f6c61622e72657365617263682e676f6f676c652e636f6d2f6173736574732f636f6c61622d62616467652e737667)](https://colab.research.google.com/github/ydataai/pandas-profiling/blob/master/examples/meteorites/meteorites.ipynb) [![Binder](https://camo.githubusercontent.com/483bae47a175c24dfbfc57390edd8b6982ac5fb3/68747470733a2f2f6d7962696e6465722e6f72672f62616467655f6c6f676f2e737667)](https://mybinder.org/v2/gh/ydataai/pandas-profiling/master?filepath=examples%2Fmeteorites%2Fmeteorites.ipynb)
+* [Titanic](https://pandas-profiling.ydata.ai/examples/master/titanic/titanic_report.html) (the "Wonderwall" of datasets) [![Open In Colab](https://camo.githubusercontent.com/52feade06f2fecbf006889a904d221e6a730c194/68747470733a2f2f636f6c61622e72657365617263682e676f6f676c652e636f6d2f6173736574732f636f6c61622d62616467652e737667)](https://colab.research.google.com/github/ydataai/pandas-profiling/blob/master/examples/titanic/titanic.ipynb) [![Binder](https://camo.githubusercontent.com/483bae47a175c24dfbfc57390edd8b6982ac5fb3/68747470733a2f2f6d7962696e6465722e6f72672f62616467655f6c6f676f2e737667)](https://mybinder.org/v2/gh/ydataai/pandas-profiling/master?filepath=examples%2Ftitanic%2Ftitanic.ipynb)
 * [NZA](https://pandas-profiling.ydata.ai/examples/master/nza/nza_report.html) (open data from the Dutch Healthcare Authority)
 * [Stata Auto](https://pandas-profiling.ydata.ai/examples/master/stata_auto/stata_auto_report.html) (1978 Automobile data)
-* [Vektis](https://pandas-profiling.ydata.ai/examples/master/vektis/vektis_report.html) (Vektis Dutch Healthcare data)
 * [Colors](https://pandas-profiling.ydata.ai/examples/master/colors/colors_report.html) (a simple colors dataset)
-* [UCI Bank Dataset](https://pandas-profiling.ydata.ai/examples/master/bank_marketing_data/uci_bank_marketing_report.html) (banking marketing dataset)
-* [RDW](https://pandas-profiling.ydata.ai/examples/master/rdw/rdw.html) (RDW, the Dutch DMV's vehicle registration 10 million rows, 71 features)
-
-
-Specific features:
-
-* [Russian Vocabulary](https://pandas-profiling.ydata.ai/examples/master/features/russian_vocabulary.html) (demonstrates text analysis)
-* [Cats and Dogs](https://pandas-profiling.ydata.ai/examples/master/features/cats-and-dogs.html) (demonstrates image analysis from the file system)
-* [Celebrity Faces](https://pandas-profiling.ydata.ai/examples/master/features/celebrity-faces.html) (demonstrates image analysis with EXIF information)
-* [Website Inaccessibility](https://pandas-profiling.ydata.ai/examples/master/features/website_inaccessibility_report.html) (demonstrates URL analysis)
-* [Orange prices](https://pandas-profiling.ydata.ai/examples/master/features/united_report.html) and [Coal prices](https://pandas-profiling.ydata.ai/examples/master/features/flatly_report.html) (showcases report themes)
+* [Vektis](https://pandas-profiling.ydata.ai/examples/master/vektis/vektis_report.html) (Vektis Dutch Healthcare data)
+* [UCI Bank Dataset](https://pandas-profiling.ydata.ai/examples/master/bank_marketing_data/uci_bank_marketing_report.html) (marketing dataset from a bank)
+* [Russian Vocabulary](https://pandas-profiling.ydata.ai/examples/master/features/russian_vocabulary.html) (100 most common Russian words, showcasing unicode text analysis)
+* [Website Inaccessibility](https://pandas-profiling.ydata.ai/examples/master/features/website_inaccessibility_report.html) (website accessibility analysis, showcasing support for URL data)
+* [Orange prices](https://pandas-profiling.ydata.ai/examples/master/features/united_report.html) and [Coal prices](https://pandas-profiling.ydata.ai/examples/master/features/flatly_report.html) (simple pricing evolution datasets, showcasing the theming options)
 
 Tutorials:
 
-* [Tutorial: report structure using Kaggle data (advanced)](https://pandas-profiling.ydata.ai/examples/master/tutorials/modify_report_structure.ipynb) (modify the report's structure) [![Open In Colab](https://camo.githubusercontent.com/52feade06f2fecbf006889a904d221e6a730c194/68747470733a2f2f636f6c61622e72657365617263682e676f6f676c652e636f6d2f6173736574732f636f6c61622d62616467652e737667)](https://colab.research.google.com/github/pandas-profiling/pandas-profiling/blob/master/examples/tutorials/modify_report_structure.ipynb) [![Binder](https://camo.githubusercontent.com/483bae47a175c24dfbfc57390edd8b6982ac5fb3/68747470733a2f2f6d7962696e6465722e6f72672f62616467655f6c6f676f2e737667)](https://mybinder.org/v2/gh/pandas-profiling/pandas-profiling/master?filepath=examples%2Ftutorials%2Fmodify_report_structure.ipynb)
+* [Tutorial: report structure using Kaggle data (advanced)](https://github.com/ydataai/pandas-profiling/blob/develop/examples/tutorials/modify_report_structure.ipynb) (modify the report's structure) [![Open In Colab](https://camo.githubusercontent.com/52feade06f2fecbf006889a904d221e6a730c194/68747470733a2f2f636f6c61622e72657365617263682e676f6f676c652e636f6d2f6173736574732f636f6c61622d62616467652e737667)](https://colab.research.google.com/github/ydataai/pandas-profiling/blob/master/examples/tutorials/modify_report_structure.ipynb) [![Binder](https://camo.githubusercontent.com/483bae47a175c24dfbfc57390edd8b6982ac5fb3/68747470733a2f2f6d7962696e6465722e6f72672f62616467655f6c6f676f2e737667)](https://mybinder.org/v2/gh/ydataai/pandas-profiling/master?filepath=examples%2Ftutorials%2Fmodify_report_structure.ipynb)
 
 
 ## Installation

--- a/docsrc/source/pages/examples.rst
+++ b/docsrc/source/pages/examples.rst
@@ -18,6 +18,8 @@ The following example reports showcase the potentialities of the package across 
 
 - `Vektis <https://pandas-profiling.ydata.ai/examples/master/vektis/vektis_report.html>`_ (Vektis Dutch Healthcare data)
 
+- `UCI Bank Dataset <https://pandas-profiling.ydata.ai/examples/master/bank_marketing_data/uci_bank_marketing_report.html>`_ (marketing dataset from a bank)
+
 - `Russian Vocabulary <https://pandas-profiling.ydata.ai/examples/master/features/russian_vocabulary.html>`_ (100 most common Russian words, showcasing unicode text analysis)
 
 - `Website Inaccessibility <https://pandas-profiling.ydata.ai/examples/master/features/website_inaccessibility_report.html>`_ (website accessibility analysis, showcasing support for URL data)
@@ -37,7 +39,7 @@ Tutorials
  :target: https://mybinder.org/v2/gh/ydataai/pandas-profiling/master?filepath=examples%2Fmeteorites%2Fmeteorites.ipynb
 .. |nasa_colab| image:: https://colab.research.google.com/assets/colab-badge.svg
  :alt: Open in Colab
- :target: https://colab.research.google.com/github/pandas-profiling/pandas-profiling/blob/master/examples/meteorites/meteorites.ipynb
+ :target: https://colab.research.google.com/github/ydataai/pandas-profiling/blob/master/examples/meteorites/meteorites.ipynb
 
 .. |titanic_binder| image:: https://mybinder.org/badge_logo.svg
  :alt: Open in Binder
@@ -45,7 +47,7 @@ Tutorials
 
 .. |titanic_colab| image:: https://colab.research.google.com/assets/colab-badge.svg
  :alt: Open in Colab
- :target: https://colab.research.google.com/github/pandas-profiling/pandas-profiling/blob/master/examples/titanic/titanic.ipynb
+ :target: https://colab.research.google.com/github/ydataai/pandas-profiling/blob/master/examples/titanic/titanic.ipynb
 
 .. |kaggle_binder| image:: https://mybinder.org/badge_logo.svg
  :alt: Open in Binder

--- a/docsrc/source/pages/examples.rst
+++ b/docsrc/source/pages/examples.rst
@@ -2,39 +2,32 @@
 Examples
 ========
 
-The following examples can give you an impression of what the package can do:
+The following example reports showcase the potentialities of the package across a wide range of dataset and data types:
 
-- `Census Income <https://pandas-profiling.github.io/pandas-profiling/examples/master/census/census_report.html>`_ (US Adult Census data relating income)
+- `Census Income <https://pandas-profiling.ydata.ai/examples/master/census/census_report.html>`_ (US Adult Census data relating income with other demographic properties)
 
-- `NASA Meteorites <https://pandas-profiling.github.io/pandas-profiling/examples/master/meteorites/meteorites_report.html>`_ (comprehensive set of meteorite landings) |nasa_binder| |nasa_colab|
+- `NASA Meteorites <https://pandas-profiling.ydata.ai/examples/master/meteorites/meteorites_report.html>`_ (comprehensive set of meteorite landing - object properties and locations) |nasa_binder| |nasa_colab|
 
-- `Titanic <https://pandas-profiling.github.io/pandas-profiling/examples/master/titanic/titanic_report.html>`_ (the "Wonderwall" of datasets) |titanic_binder| |titanic_colab|
+- `Titanic <https://pandas-profiling.ydata.ai/examples/master/titanic/titanic_report.html>`_ (the "Wonderwall" of datasets) |titanic_binder| |titanic_colab|
 
-- `NZA <https://pandas-profiling.github.io/pandas-profiling/examples/master/nza/nza_report.html>`_ (open data from the Dutch Healthcare Authority)
+- `NZA <https://pandas-profiling.ydata.ai/examples/master/nza/nza_report.html>`_ (open data from the Dutch Healthcare Authority)
 
-- `Stata Auto <https://pandas-profiling.github.io/pandas-profiling/examples/master/stata_auto/stata_auto_report.html>`_ (1978 Automobile data, Stata format)
+- `Stata Auto <https://pandas-profiling.ydata.ai/examples/master/stata_auto/stata_auto_report.html>`_ (1978 Automobile data, Stata format)
 
-- `Colors <https://pandas-profiling.github.io/pandas-profiling/examples/master/colors/colors_report.html>`_ (a simple colors dataset)
+- `Colors <https://pandas-profiling.ydata.ai/examples/master/colors/colors_report.html>`_ (a simple colors dataset)
 
-- `Vektis <https://pandas-profiling.github.io/pandas-profiling/examples/master/vektis/vektis_report.html>`_ (Vektis Dutch Healthcare data)
+- `Vektis <https://pandas-profiling.ydata.ai/examples/master/vektis/vektis_report.html>`_ (Vektis Dutch Healthcare data)
 
-Showcasing specific features
-----------------------------
+- `Russian Vocabulary <https://pandas-profiling.ydata.ai/examples/master/features/russian_vocabulary.html>`_ (100 most common Russian words, showcasing unicode text analysis)
 
-- `Russian Vocabulary <https://pandas-profiling.github.io/pandas-profiling/examples/master/features/russian_vocabulary.html>`_ (demonstrates unicode text analysis)
+- `Website Inaccessibility <https://pandas-profiling.ydata.ai/examples/master/features/website_inaccessibility_report.html>`_ (website accessibility analysis, showcasing support for URL data)
 
-- `Cats and Dogs <https://pandas-profiling.github.io/pandas-profiling/examples/master/features/cats-and-dogs.html>`_ (demonstrates image analysis from the file system, `source <https://pandas-profiling.github.io/pandas-profiling/examples/master/features/images_cats_and_dogs.py>`__)
-
-- `Celebrity Faces <https://pandas-profiling.github.io/pandas-profiling/examples/master/features/celebrity-faces.html>`_ (demonstrates image analysis with EXIF information, `source <https://pandas-profiling.github.io/pandas-profiling/examples/master/features/images_exif.py>`_)
-
-- `Website Inaccessibility <https://pandas-profiling.github.io/pandas-profiling/examples/master/features/website_inaccessibility_report.html>`_ (demonstrates URL analysis)
-
-- `Orange prices <https://pandas-profiling.github.io/pandas-profiling/examples/master/features/united_report.html>`_ and `Coal prices <https://pandas-profiling.github.io/pandas-profiling/examples/master/features/flatly_report.html>`_ (showcase report themes)
+- `Orange prices <https://pandas-profiling.ydata.ai/examples/master/features/united_report.html>`_ and `Coal prices <https://pandas-profiling.ydata.ai/examples/master/features/flatly_report.html>`_ (simple pricing evolution datasets, showcasing the theming options)
 
 Tutorials
 ---------
 
-- `Tutorial: report structure using Kaggle data (advanced) <https://pandas-profiling.github.io/pandas-profiling/examples/master/tutorials/modify_report_structure.ipynb>`_ (modify the report's structure) |kaggle_binder| |kaggle_colab|
+- `Tutorial: report structure using Kaggle data (advanced) <https://github.com/ydataai/pandas-profiling/blob/master/examples/tutorials/modify_report_structure.ipynb>`_ (modify the report's structure) |kaggle_binder| |kaggle_colab|
 
 
 
@@ -56,8 +49,8 @@ Tutorials
 
 .. |kaggle_binder| image:: https://mybinder.org/badge_logo.svg
  :alt: Open in Binder
- :target: https://mybinder.org/v2/gh/pandas-profiling/pandas-profiling/master?filepath=examples%2Fkaggle%2Fmodify_report_structure.ipynb
+ :target: https://mybinder.org/v2/gh/ydata-ai/pandas-profiling/master?filepath=examples%2Fkaggle%2Fmodify_report_structure.ipynb
 
 .. |kaggle_colab| image:: https://colab.research.google.com/assets/colab-badge.svg
  :alt: Open in Colab
- :target: https://colab.research.google.com/github/pandas-profiling/pandas-profiling/blob/master/examples/kaggle/modify_report_structure.ipynb)
+ :target: https://colab.research.google.com/github/ydataai/pandas-profiling/blob/master/examples/tutorials/modify_report_structure.ipynb

--- a/docsrc/source/pages/examples.rst
+++ b/docsrc/source/pages/examples.rst
@@ -34,14 +34,14 @@ Tutorials
 
 .. |nasa_binder| image:: https://mybinder.org/badge_logo.svg
  :alt: Open in Binder
- :target: https://mybinder.org/v2/gh/pandas-profiling/pandas-profiling/master?filepath=examples%2Fmeteorites%2Fmeteorites.ipynb
+ :target: https://mybinder.org/v2/gh/ydataai/pandas-profiling/master?filepath=examples%2Fmeteorites%2Fmeteorites.ipynb
 .. |nasa_colab| image:: https://colab.research.google.com/assets/colab-badge.svg
  :alt: Open in Colab
  :target: https://colab.research.google.com/github/pandas-profiling/pandas-profiling/blob/master/examples/meteorites/meteorites.ipynb
 
 .. |titanic_binder| image:: https://mybinder.org/badge_logo.svg
  :alt: Open in Binder
- :target: https://mybinder.org/v2/gh/pandas-profiling/pandas-profiling/master?filepath=examples%2Ftitanic%2Ftitanic.ipynb
+ :target: https://mybinder.org/v2/gh/ydataai/pandas-profiling/master?filepath=examples%2Ftitanic%2Ftitanic.ipynb
 
 .. |titanic_colab| image:: https://colab.research.google.com/assets/colab-badge.svg
  :alt: Open in Colab
@@ -49,7 +49,7 @@ Tutorials
 
 .. |kaggle_binder| image:: https://mybinder.org/badge_logo.svg
  :alt: Open in Binder
- :target: https://mybinder.org/v2/gh/ydata-ai/pandas-profiling/master?filepath=examples%2Fkaggle%2Fmodify_report_structure.ipynb
+ :target: https://mybinder.org/v2/gh/ydataai/pandas-profiling/master?filepath=examples%2Fkaggle%2Fmodify_report_structure.ipynb
 
 .. |kaggle_colab| image:: https://colab.research.google.com/assets/colab-badge.svg
  :alt: Open in Colab


### PR DESCRIPTION
This PR: 
- Removed outdated examples from the documentation
- Fixes links (Colab, Binder, to repo)
- Adjusts wording and organization of the examples (remove the _"Showcase specific features"_ section because almost all examples showcase specific features - handling different types of datasets of different sizes, for instance - and details can be added in the description)
- Syncs examples in the `README.md` with the documentation

@sbrugman This is my first time contributing, let me know if I am not doing things right or of any adjustments needed. 