### PR TITLE
Deprecate pdoc-based documentation page

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_form.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yaml
@@ -9,7 +9,7 @@ body:
       value: |
         Thanks for taking the time to fill out this bug report!
         Provide a concise summary of the issue in the title field above.
-        The [documentation](https://pandas-profiling.ydata.ai/docs/master/rtd/pages/support.html) contains instructions on creating bug reports.
+        The [documentation](https://pandas-profiling.ydata.ai/docs/master/pages/support.html) contains instructions on creating bug reports.
   - type: textarea
     id: current-behavior
     attributes:
@@ -62,7 +62,7 @@ body:
     id: dependencies
     attributes:
       label: Dependencies
-      description: Please report versions of relevant dependencies (e.g. via `pip freeze` or `conda list`, [more information](https://pandas-profiling.ydata.ai/docs/master/rtd/pages/support.html))
+      description: Please report versions of relevant dependencies (e.g. via `pip freeze` or `conda list`, [more information](https://pandas-profiling.ydata.ai/docs/master/pages/support.html))
       placeholder: |
         pandas==1.4.2
         numpy==2.3.4
@@ -86,12 +86,12 @@ body:
         Please complete the checklist below to ensure the bug report is helpful and can be addressed effectively
         
         Tips:
-          - Help for writing better bug reports is available in the [documentation](https://pandas-profiling.ydata.ai/docs/master/rtd/pages/support.html).
+          - Help for writing better bug reports is available in the [documentation](https://pandas-profiling.ydata.ai/docs/master/pages/support.html).
           - If the description consists of multiple non-related bugs, you are encouraged to create separate issues.
       options:
         - label: There is not yet another bug report for this issue in the [issue tracker](https://github.com/ydataai/pandas-profiling/issues)
           required: true
         - label: The problem is reproducible from this bug report. [This guide](http://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports) can help to craft a minimal bug report.
           required: true
-        - label: The issue has not been resolved by the entries listed under [Frequent Issues](https://pandas-profiling.ydata.ai/docs/master/rtd/pages/support.html#frequent-issues).
+        - label: The issue has not been resolved by the entries listed under [Frequent Issues](https://pandas-profiling.ydata.ai/docs/master/pages/support.html#frequent-issues).
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request_form.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request_form.yaml
@@ -8,7 +8,7 @@ body:
       value: |
         You are very much welcome in sharing what functionality is missing in `pandas-profiling`.
         Provide a concise summary of the feature in the title field above.
-        The [documentation](https://pandas-profiling.ydata.ai/docs/master/rtd/pages/contribution_guidelines.html) contains instructions on contributing to this package.
+        The [documentation](https://pandas-profiling.ydata.ai/docs/master/pages/contribution_guidelines.html) contains instructions on contributing to this package.
 
   - type: textarea
     id: missing-functionality

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,7 @@
 docs:
 	rm -rf docs/
 	mkdir docs/
-	# pdoc3
 	cp -a ./docsrc/assets/ ./docs/assets/
-	pdoc3 --html --force --output-dir docs pandas_profiling
-	mv docs/pandas_profiling/* docs
-	rmdir docs/pandas_profiling
 	# sphinx
 	cd docsrc/ && make github
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 docs:
 	rm -rf docs/
 	mkdir docs/
-	cp -a ./docsrc/assets/ ./docs/assets/
 	# sphinx
 	cd docsrc/ && make github
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@
 
 
 <p align="center">
-  <a href="https://pandas-profiling.ydata.ai/docs/master/rtd/">Documentation</a>
+  <a href="https://pandas-profiling.ydata.ai/docs/master/">Documentation</a>
   |
   <a href="https://slack.ydata.ai">Slack</a>
   | 
   <a href="https://stackoverflow.com/questions/tagged/pandas-profiling">Stack Overflow</a>
   |
-  <a href="https://pandas-profiling.ydata.ai/docs/master/rtd/pages/changelog.html#changelog">Latest changelog</a>
+  <a href="https://pandas-profiling.ydata.ai/docs/master/pages/changelog.html#changelog">Latest changelog</a>
 
 </p>
 
@@ -120,7 +120,7 @@ python setup.py install
 
 ## Documentation
 
-The documentation for `pandas_profiling` can be found [here](https://pandas-profiling.ydata.ai/docs/master/rtd/). Previous documentation is still available [here](https://pandas-profiling.ydata.ai/docs/master/).
+The documentation for `pandas_profiling` can be found [here](https://pandas-profiling.ydata.ai/docs/master).
 
 ### Getting started
 
@@ -146,7 +146,7 @@ You can configure the profile report in any way you like. The example code below
 profile = ProfileReport(df, title="Pandas Profiling Report", explorative=True)
 ```
 
-Learn more about configuring `pandas-profiling` on the [Advanced usage](https://pandas-profiling.ydata.ai/docs/master/rtd/pages/advanced_usage.html) page.
+Learn more about configuring `pandas-profiling` on the [Advanced usage](https://pandas-profiling.ydata.ai/docs/master/pages/advanced_usage.html) page.
 
 #### Jupyter Notebook
 
@@ -223,7 +223,7 @@ A set of options is available in order to adapt the report generated.
 
 More settings can be found in the [default configuration file](https://github.com/ydataai/pandas-profiling/blob/master/src/pandas_profiling/config_default.yaml) and [minimal configuration file](https://github.com/ydataai/pandas-profiling/blob/master/src/pandas_profiling/config_minimal.yaml).
 
-You find the configuration docs on the advanced usage page [here](https://pandas-profiling.ydata.ai/docs/master/rtd/pages/advanced_usage.html)
+You find the configuration docs on the advanced usage page [here](https://pandas-profiling.ydata.ai/docs/master/pages/advanced_usage.html)
 
 **Example**
 ```python
@@ -289,7 +289,7 @@ This a world-class open-source library that helps you to maintain data quality a
 Great Expectations allows you to create Expectations (which are basically unit tests for your data) and Data Docs (conveniently shareable HTML data reports).
 `pandas-profiling` features a method to create a suite of Expectations based on the results of your ProfileReport, which you can store, and use to validate another (or future) dataset.
 
-You can find more details on the Great Expectations integration [here](https://pandas-profiling.ydata.ai/docs/master/rtd/pages/great_expectations_integration.html)
+You can find more details on the Great Expectations integration [here](https://pandas-profiling.ydata.ai/docs/master/pages/great_expectations_integration.html)
 
 </td>
 </tr>
@@ -307,7 +307,7 @@ In the meantime, user customized summarizations and type definitions are now ful
 
 ## Contributing
 
-Read on getting involved in the [Contribution Guide](https://pandas-profiling.ydata.ai/docs/master/rtd/pages/contribution_guidelines.html).
+Read on getting involved in the [Contribution Guide](https://pandas-profiling.ydata.ai/docs/master/pages/contribution_guidelines.html).
 
 A low threshold place to ask questions or start contributing is by reaching out on the pandas-profiling Slack. [Join the Slack community](https://slack.ydata.ai).
 

--- a/docsrc/Makefile
+++ b/docsrc/Makefile
@@ -13,7 +13,7 @@ help:
 
 github:
 	@make html
-	@cp -a build/html/. ../docs/rtd
+	@cp -a build/html/. ../docs/
 	@rm -rf build
 
 .PHONY: help Makefile

--- a/docsrc/make.bat
+++ b/docsrc/make.bat
@@ -31,7 +31,7 @@ goto end
 
 :github
 call make html
-robocopy .\build\html ..\docs\rtd /E /MOVE
+robocopy .\build\html ..\docs\ /E /MOVE
 rmdir .\build /s /q
 goto end
 

--- a/docsrc/source/pages/announcements/2020-05-07-release-v2-7-0.rst
+++ b/docsrc/source/pages/announcements/2020-05-07-release-v2-7-0.rst
@@ -15,7 +15,7 @@ Moreover, the progress bar provides more information on the building phase and s
 
 Documentation
 ^^^^^^^^^^^^^
-This version introduces `more elaborate documentation <https://pandas-profiling.github.io/pandas-profiling/docs/master/rtd/index.html>`_ powered by Sphinx.
+This version introduces `more elaborate documentation <https://pandas-profiling.github.io/pandas-profiling/docs/master/index.html>`_ powered by Sphinx.
 The previously used pdoc3 has been adequate initially, however misses functionality and extensibility.
 Several recurring topics are now documented, for instance the configuration parameters are documented and there are pages on big datasets, sensitive data, integrations and resources.
 
@@ -27,7 +27,7 @@ It's extra exciting that GitHub **matches your contribution** for the first year
 
 Find more information here:
 
- - `Changelog v2.7.0 <https://pandas-profiling.github.io/pandas-profiling/docs/master/rtd/pages/changelog.html#changelog-v2-7-0>`_
+ - `Changelog v2.7.0 <https://pandas-profiling.github.io/pandas-profiling/docs/master/pages/changelog.html#changelog-v2-7-0>`_
  - `Sponsor the project on GitHub <https://github.com/sponsors/sbrugman>`_
 
  *May 7, 2020 💘*

--- a/docsrc/source/pages/announcements/2020-05-12-release-v2-8-0.rst
+++ b/docsrc/source/pages/announcements/2020-05-12-release-v2-8-0.rst
@@ -4,4 +4,4 @@ Version v2.8.0 released
 News for users working with image datasets: ``pandas-profiling`` now has build-in supports for Files and Images.
 Moreover, the text analysis features have also been reworked, providing more informative statistics.
 
-For a better feel, have a look at the `examples <https://pandas-profiling.github.io/pandas-profiling/docs/master/rtd/pages/examples.html#showcasing-specific-features>`_ section in the docs or read the changelog for a complete view of the changes.
+For a better feel, have a look at the `examples <https://pandas-profiling.github.io/pandas-profiling/docs/master/pages/examples.html#showcasing-specific-features>`_ section in the docs or read the changelog for a complete view of the changes.

--- a/docsrc/source/pages/changelog/v2_11_0.rst
+++ b/docsrc/source/pages/changelog/v2_11_0.rst
@@ -3,7 +3,7 @@ Changelog v2.11.0
 
 🎉 Features
 ^^^^^^^^^^^
-- Great Expectations integration `[430] <https://github.com/pandas-profiling/pandas-profiling/issues/430>`_ `docs <https://pandas-profiling.github.io/pandas-profiling/docs/master/rtd/pages/great_expectations_integration.html>`_ (thanks @spbail, @talagluck and the Great Expectations team).
+- Great Expectations integration `[430] <https://github.com/pandas-profiling/pandas-profiling/issues/430>`_ `docs <https://pandas-profiling.github.io/pandas-profiling/docs/master/pages/great_expectations_integration.html>`_ (thanks @spbail, @talagluck and the Great Expectations team).
 - Introduced the ``infer_dtypes`` parameter to control automatic inference of data types `[676] <https://github.com/pandas-profiling/pandas-profiling/issues/676>`_ (thanks @mohith7548 and @ieaves).
 - Improved JSON representation for pd.Series, pd.DataFrame, numpy data and Samples.
 

--- a/make.bat
+++ b/make.bat
@@ -3,10 +3,6 @@ setlocal enabledelayedexpansion
 
 IF "%1%" == "docs" (
     mkdir docs/
-    :: pdoc3
-    robocopy .\docsrc\assets\ .\docs\assets\
-    pdoc3 --html  --force --output-dir docs pandas_profiling
-    robocopy .\docs\pandas_profiling .\docs /E /MOVE
     :: sphinx
     cd docsrc/ && make github
     ECHO "Docs updated!"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@ isort>=5.0.7
 pre-commit>=2.8.2
 virtualenv>=20.0.33
 twine
-pdoc3
 wheel
 recommonmark>=0.6.0
 sphinx_rtd_theme>=0.4.3


### PR DESCRIPTION
Sphinx with an RTD theme is the current documentation system. However, a pdoc3 -based documentation page is still up, although it's not being used. This branch deprecates it:

- Removes all `pdoc` related instructions from makefiles and similars.
- Updates links to documentation across the repo (from `docs/rtd/` to `/docs/`)

**Still missing:** 
- Set up redirect from `/docs/rtd` to `/docs/` (release CI/CD pipeline)