### PR TITLE
chore: add a 404 redirecting to documentation's home

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Page not found, redirecting to documentation's home</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=./docs/master/index.html">
+    <link rel="canonical" href="https://pandas-profiling.ydata.ai/docs/master/index.html">
+  </head>
+</html>


### PR DESCRIPTION
What the title says: 404.html page which automatically redirects to the docs' home to handle all the changes in documentation structure and location currently in progress (`pdoc` deprecation, new internal and external structure)