### PR TITLE
Improvements to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pandas Profiling
+# `pandas-profiling`
 
 ![Pandas Profiling Logo Header](https://pandas-profiling.ydata.ai/docs/assets/logo_header.png)
 
@@ -12,7 +12,7 @@
 <p align="center">
   <a href="https://pandas-profiling.ydata.ai/docs/master/">Documentation</a>
   |
-  <a href="https://slack.ydata.ai">Slack</a>
+  <a href="https://slack.datacentricai.community/">Slack</a>
   | 
   <a href="https://stackoverflow.com/questions/tagged/pandas-profiling">Stack Overflow</a>
   |
@@ -20,41 +20,100 @@
 
 </p>
 
-Generates profile reports from a pandas `DataFrame`. 
+`pandas-profiling` generates profile reports from a pandas `DataFrame`. The pandas `df.describe()` function is handy yet a little basic for exploratory data analysis. `pandas-profiling` extends pandas DataFrame with `df.profile_report()`, which automatically generates a standardized univariate and multivariate report for data understanding.
 
-The pandas `df.describe()` function is great but a little basic for serious exploratory data analysis. 
-`pandas_profiling` extends the pandas DataFrame with `df.profile_report()` for quick data analysis.
+For each column, the following information (whenever relevant for the column type) is presented in an interactive HTML report:
 
-For each column the following statistics - if relevant for the column type - are presented in an interactive HTML report:
+- **Type inference**: detect the types of columns in a DataFrame
+- **Essentials**: type, unique values, indication of missing values
+- **Quantile statistics**: minimum value, Q1, median, Q3, maximum, range, interquartile range
+- **Descriptive statistics**: mean, mode, standard deviation, sum, median absolute deviation, coefficient of variation, kurtosis, skewness
+- **Most frequent and extreme values**
+- **Histograms**: categorical and numerical
+- **Correlations**: high correlation warnings, based on different correlation metrics (Spearman, Pearson, Kendall, Cramér’s V, Phik)
+- **Missing values**: through counts, matrix, heatmap and dendrograms
+- **Duplicate rows**: list of the most common duplicated rows
+- **Text analysis**: most common categories (uppercase, lowercase, separator), scripts (Latin, Cyrillic) and blocks (ASCII, Cyrilic)
+- **File and Image analysis**: file sizes, creation dates, dimensions, indication of truncated images and existance of EXIF metadata
 
-* **Type inference**: detect the [types](#types) of columns in a dataframe.
-* **Essentials**: type, unique values, missing values
-* **Quantile statistics** like minimum value, Q1, median, Q3, maximum, range, interquartile range
-* **Descriptive statistics** like mean, mode, standard deviation, sum, median absolute deviation, coefficient of variation, kurtosis, skewness
-* **Most frequent values**
-* **Histogram**
-* **Correlations** highlighting of highly correlated variables, Spearman, Pearson and Kendall matrices
-* **Missing values** matrix, count, heatmap and dendrogram of missing values
-* **Text analysis** learn about categories (Uppercase, Space), scripts (Latin, Cyrillic) and blocks (ASCII) of text data.
-* **File and Image analysis** extract file sizes, creation dates and dimensions and scan for truncated images or those containing EXIF information.
+The report contains three additional sections:
 
-## Announcements
+- **Overview**: mostly global details about the dataset (number of records, number of variables, overall missigness and duplicates, memory footprint)
+- **Alerts**: a comprehensive and automatic list of potential data quality issues (high correlation, skewness, uniformity, zeros, missing values, constant values, between others)
+- **Reproduction**: technical details about the analysis (time, version and configuration)
 
-**Spark backend in progress**: We can happily announce that we're nearing v1 for the Spark backend for generating profile reports.
-Beta testers wanted! The Spark backend will be released as a pre-release for this package.
 
-**Monitoring time series?**: I'd like to draw your attention to [popmon](https://github.com/ing-bank/popmon). Whereas pandas-profiling allows you to explore patterns in a single dataset, popmon allows you to uncover temporal patterns. It's worth checking out!
-
----
-
-_Contents:_ **[Examples](#examples)** |
-**[Installation](#installation)** | **[Documentation](#documentation)** |
-**[Large datasets](#large-datasets)** | **[Command line usage](#command-line-usage)** |
-**[Advanced usage](#advanced-usage)** | **[Support](#support)** | **[Go beyond](#go-beyond)** |
-**[Support the project](#supporting-open-source)** | **[Types](#types)** | **[How to contribute](#contributing)** |
-**[Editor Integration](#editor-integration)** | **[Dependencies](#dependencies)**
+> ⚡ Looking for a Spark backend to profile large datasets? WIP, track progress [here](https://github.com/ydataai/pandas-profiling/projects/3).
+> 
+> ⌛ Interested in uncovering temporal patterns? Check out [popmon](https://github.com/ing-bank/popmon).
 
 ---
+
+## Quickstart
+
+Start by loading your pandas `DataFrame` as you normally would, e.g. by using:
+
+```python
+import numpy as np
+import pandas as pd
+from pandas_profiling import ProfileReport
+
+df = pd.DataFrame(np.random.rand(100, 5), columns=["a", "b", "c", "d", "e"])
+```
+
+To generate the standard profiling report, merely run:
+
+```python
+profile = ProfileReport(df, title="Pandas Profiling Report")
+```
+
+### Using inside Jupyter Notebooks
+
+There are two interfaces to consume the report inside a Jupyter notebook: through widgets and through an embedded HTML report.
+
+<img alt="Notebook Widgets" src="https://pandas-profiling.ydata.ai/docs/master/assets/widgets.gif" width="800" />
+
+The above is achieved by simply displaying the report as a set of widgets. In a Jupyter Notebook, run:
+
+```python
+profile.to_widgets()
+```
+
+The HTML report can be directly embedded in a cell in a similar fashion:
+
+```python
+profile.to_notebook_iframe()
+```
+
+<img alt="HTML" src="https://pandas-profiling.ydata.ai/docs/master/assets/iframe.gif" width="800" />
+
+### Exporting the report to a file
+
+To generate a HTML report file, save the ProfileReport to an object and use the to_file() function:
+
+```python
+profile.to_file("your_report.html")
+```
+
+Alternatively, the report's data can be obtained as a JSON file:
+
+```python
+# As a JSON string
+json_data = profile.to_json()
+
+# As a file
+profile.to_file("your_report.json")
+```
+
+### Command line usage
+
+For standard formatted CSV files (which can be read directly by pandas without additional settings), the pandas_profiling executable can be used in the command line. The example below generates a report named Example Profiling Report, using a configuration file called default.yaml, in the file report.html by processing a data.csv dataset.
+
+```sh
+pandas_profiling --title "Example Profiling Report" --config_file default.yaml data.csv report.html
+```
+
+Additional details on the CLI [on the documentation](https://pandas-profiling.ydata.ai/docs/master/pages/getting_started/quickstart.html#command-line-usage).
 
 ## Examples
 
@@ -74,247 +133,39 @@ The following example reports showcase the potentialities of the package across 
 
 ## Installation
 
-### Using pip
+Additional details, including information about widgets, are available [on the documentation](https://pandas-profiling.ydata.ai/docs/master/pages/getting_started/installation.html).
 
+### Using pip
 [![PyPi Downloads](https://pepy.tech/badge/pandas-profiling)](https://pepy.tech/project/pandas-profiling)
 [![PyPi Monthly Downloads](https://pepy.tech/badge/pandas-profiling/month)](https://pepy.tech/project/pandas-profiling/month)
 [![PyPi Version](https://badge.fury.io/py/pandas-profiling.svg)](https://pypi.org/project/pandas-profiling/)
 
-You can install using the pip package manager by running
+You can install using the `pip` package manager by running:
 
 ```sh
-pip install pandas-profiling[notebook]
+pip install -U pandas-profiling[notebook]
 ```
 
-Alternatively, you could install the latest version directly from Github:
-
-```sh
-pip install https://github.com/ydataai/pandas-profiling/archive/master.zip
-```    
-    
 ### Using conda
-
 [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pandas-profiling.svg)](https://anaconda.org/conda-forge/pandas-profiling)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pandas-profiling.svg)](https://anaconda.org/conda-forge/pandas-profiling) 
- 
-You can install using the conda package manager by running
+
+
+You can install using the `conda` package manager by running:
 
 ```sh
 conda install -c conda-forge pandas-profiling
 ```
 
-### From source
+### From source (development)
 
-Download the source code by cloning the repository or by pressing ['Download ZIP'](https://github.com/ydataai/pandas-profiling/archive/master.zip) on this page. 
+Download the source code by cloning the repository or by clicking on ['Download ZIP'](https://github.com/ydataai/pandas-profiling/archive/master.zip).
 
 Install by navigating to the proper directory and running:
 
 ```sh
 python setup.py install
 ```
-
-## Documentation
-
-The documentation for `pandas_profiling` can be found [here](https://pandas-profiling.ydata.ai/docs/master).
-
-### Getting started
-
-Start by loading in your pandas DataFrame, e.g. by using:
-
-```python
-import numpy as np
-import pandas as pd
-from pandas_profiling import ProfileReport
-
-df = pd.DataFrame(np.random.rand(100, 5), columns=["a", "b", "c", "d", "e"])
-```
-To generate the report, run:
-```python
-profile = ProfileReport(df, title="Pandas Profiling Report")
-```
-
-### Explore deeper
-
-You can configure the profile report in any way you like. The example code below loads the explorative configuration, that includes many features for text (length distribution, unicode information), files (file size, creation time) and images (dimensions, exif information). If you are interested what exact settings were used, you can compare with the [default configuration file](https://github.com/ydataai/pandas-profiling/blob/master/src/pandas_profiling/config_default.yaml).
-
-```python
-profile = ProfileReport(df, title="Pandas Profiling Report", explorative=True)
-```
-
-Learn more about configuring `pandas-profiling` on the [Advanced usage](https://pandas-profiling.ydata.ai/docs/master/pages/advanced_usage/available_settings.html) page.
-
-#### Jupyter Notebook
-
-We recommend generating reports interactively by using the Jupyter notebook. 
-There are two interfaces (see animations below): through widgets and through a HTML report.
-
-<img alt="Notebook Widgets" src="https://pandas-profiling.ydata.ai/docs/master/assets/widgets.gif" width="800" />
-
-This is achieved by simply displaying the report. In the Jupyter Notebook, run:
-
-```python
-profile.to_widgets()
-```
-
-The HTML report can be included in a Jupyter notebook:
-
-<img alt="HTML" src="https://pandas-profiling.ydata.ai/docs/master/assets/iframe.gif" width="800" />
-
-Run the following code:
-
-```python
-profile.to_notebook_iframe()
-```
-
-#### Saving the report
-
-If you want to generate a HTML report file, save the `ProfileReport` to an object and use the `to_file()` function:
-```python
-profile.to_file("your_report.html")
-```
-
-Alternatively, you can obtain the data as JSON:
-```python
-# As a string
-json_data = profile.to_json()
-
-# As a file
-profile.to_file("your_report.json")
-```
-
-### Large datasets
-
-Version 2.4 introduces minimal mode. 
-
-This is a default configuration that disables expensive computations (such as correlations and duplicate row detection).
-
-Use the following syntax:
-
-```python
-profile = ProfileReport(large_dataset, minimal=True)
-profile.to_file("output.html")
-```
-
-Benchmarks are available [here](https://pandas-profiling.ydata.ai/dev/bench/).
-
-### Command line usage
-
-For standard formatted CSV files that can be read immediately by pandas, you can use the `pandas_profiling` executable. 
-
-Run the following for information about options and arguments.
-
-```sh
-pandas_profiling -h
-```
-
-### Advanced usage
-
-A set of options is available in order to adapt the report generated.
-
-* `title` (`str`): Title for the report ('Pandas Profiling Report' by default).
-* `pool_size` (`int`): Number of workers in thread pool. When set to zero, it is set to the number of CPUs available (0 by default).
-* `progress_bar` (`bool`): If True, `pandas-profiling` will display a progress bar.
-* `infer_dtypes` (`bool`): When `True` (default) the `dtype` of variables are inferred using `visions` using the typeset logic (for instance a column that has integers stored as string will be analyzed as if being numeric).
-
-More settings can be found in the [default configuration file](https://github.com/ydataai/pandas-profiling/blob/master/src/pandas_profiling/config_default.yaml) and [minimal configuration file](https://github.com/ydataai/pandas-profiling/blob/master/src/pandas_profiling/config_minimal.yaml).
-
-You find the configuration docs on the advanced usage page [here](https://pandas-profiling.ydata.ai/docs/master/pages/advanced_usage/available_settings.html)
-
-**Example**
-```python
-profile = df.profile_report(
-    title="Pandas Profiling Report", plot={"histogram": {"bins": 8}}
-)
-profile.to_file("output.html")
-```
-
-## Support
-Need help? Want to share a perspective? Want to report a bug? Ideas for collaboration? 
-You can reach out via the following channels:
-
-- [Stack Overflow](https://stackoverflow.com/questions/tagged/pandas-profiling): ideal for asking questions on how to use the package
-- [Github Issues](https://github.com/ydataai/pandas-profiling/issues): bugs, proposals for change, feature requests
-- [Slack](https://slack.ydata.ai): general chat, questions, collaboration
-- [Email](mailto:developers@ydata.ai): project collaboration or sponsoring
-
-## Go beyond
-
-### Popmon
-
-<table>
-<tr>
-<td>
-
-<a href="https://github.com/ing-bank/popmon">
-	<img alt="Popmon" src="https://raw.githubusercontent.com/ing-bank/popmon/master/docs/source/assets/popmon-logo.png" width="900" />
-</a>
-	
-</td>
-<td>
-
-For many real-world problems we are interested how the data changes over time. 
-The excellent package `popmon` allows you to profile and monitor data trends over time and generates reports in a similar fashion as you're used to using pandas-profiling.
-Inspecting the report often shows patterns that are going by undetected during standard data exploration.
-Moreover, popmon can be used to monitor the stability of input and output of machine learning models.
-The package is fully open-source and you can find it [here](https://github.com/ing-bank/popmon)! 
-
-To learn more on Popmon, have a look at these resources [here](https://github.com/ing-bank/popmon#resources)
-
-</td>
-</tr>
-</table>
-
-
-### Great Expectations
-
-<table>
-<tr>
-<td>
-
-<a href="https://www.greatexpectations.io">
-<img alt="Great Expectations" src="https://github.com/great-expectations/great_expectations/raw/develop/generic_dickens_protagonist.png" width="900" />
-</a>
-	
-</td>
-<td>
-
-Profiling your data is closely related to data validation: often validation rules are defined in terms of well-known statistics.
-For that purpose, `pandas-profiling` integrates with [Great Expectations](https://www.greatexpectations.io). 
-This a world-class open-source library that helps you to maintain data quality and improve communication about data between teams.
-Great Expectations allows you to create Expectations (which are basically unit tests for your data) and Data Docs (conveniently shareable HTML data reports).
-`pandas-profiling` features a method to create a suite of Expectations based on the results of your ProfileReport, which you can store, and use to validate another (or future) dataset.
-
-You can find more details on the Great Expectations integration [here](https://pandas-profiling.ydata.ai/docs/master/pages/integrations/great_expectations.html)
-
-</td>
-</tr>
-</table>
-
-## Types
-
-Types are a powerful abstraction for effective data analysis, that goes beyond the logical data types (integer, float etc.).
-`pandas-profiling` currently, recognizes the following types: _Boolean, Numerical, Date, Categorical, URL, Path, File_ and _Image_.
-
-We have developed a type system for Python, tailored for data analysis: [visions](https://github.com/dylan-profiler/visions).
-Choosing an appropriate typeset can both improve the overall expressiveness and reduce the complexity of your analysis/code.
-To learn more about `pandas-profiling`'s type system, check out the default implementation [here](https://github.com/ydataai/pandas-profiling/blob/develop/src/pandas_profiling/model/typeset.py).
-In the meantime, user customized summarizations and type definitions are now fully supported - if you have a specific use-case please reach out with ideas or a PR!
-
-## Contributing
-
-Read on getting involved in the [Contribution Guide](https://pandas-profiling.ydata.ai/docs/master/pages/support_contrib/contribution_guidelines.html).
-
-A low threshold place to ask questions or start contributing is by reaching out on the pandas-profiling Slack. [Join the Slack community](https://slack.ydata.ai).
-
-## Editor integration
-
-Some Integrated Development Environments integrate with `pandas-profiling`. See the [Integrations documentation page](https://pandas-profiling.ydata.ai/docs/master/pages/integrations/ides.html) for details.
-
-### Other integrations
-
-Other editor integrations may be contributed via pull requests.
-
-## Dependencies
 
 The profile report is written in HTML and CSS, which means `pandas-profiling` requires a modern browser. 
 
@@ -325,4 +176,51 @@ You need [Python 3](https://python3statement.org/) to run this package. Other de
 | [requirements.txt](https://github.com/ydataai/pandas-profiling/blob/master/requirements.txt) | Package requirements|
 | [requirements-dev.txt](https://github.com/ydataai/pandas-profiling/blob/master/requirements-dev.txt)  |  Requirements for development|
 | [requirements-test.txt](https://github.com/ydataai/pandas-profiling/blob/master/requirements-test.txt) | Requirements for testing|
-| [setup.py](https://github.com/ydataai/pandas-profiling/blob/master/setup.py) | Requirements for Widgets etc. |
+| [setup.py](https://github.com/ydataai/pandas-profiling/blob/master/setup.py) | Requirements for widgets etc. |
+
+## Use cases
+
+The documentation includes guides, tips and tricks for tackling commmon use cases:
+
+| Use case | Description |
+|---|---|
+| [Profiling large datasets](https://pandas-profiling.ydata.ai/docs/master/pages/use_cases/big_data.html ) | Tips on how to prepare data and configure `pandas-profiling` for working with large datasets |
+| [Handling sensitive data](https://pandas-profiling.ydata.ai/docs/master/pages/use_cases/sensitive_data.html ) | Generating reports which are mindful about sensitive data in the input dataset |
+| [Dataset metadata and data dictionaries](https://pandas-profiling.ydata.ai/docs/master/pages/use_cases/metadata.html) | Embedding overall dataset details and column-specific data dictionary for easier sharing |
+| [Customizing the report's appearance](https://pandas-profiling.ydata.ai/docs/master/pages/use_cases/custom_report_appearance.html ) | Personalising the appearance of the report's page and of its plots |
+
+## Integrations
+
+To maximize its usefulness in real world contexts, `pandas-profiling` has a set of implicit and explicit integration with a variety of other actors in the Data Science ecosystem: 
+
+| Integration type | Description |
+|---|---|
+| [Other DataFrame libraries](https://pandas-profiling.ydata.ai/docs/master/pages/integrations/other_dataframe_libraries.html) | How to compute the profiling of data stored in libraries different than pandas |
+| [Great Expectations](https://pandas-profiling.ydata.ai/docs/master/pages/integrations/great_expectations.html) | Generating [Great Expectations](https://greatexpectations.io) expectations suites straight from a profiling report |
+| [Interactive applications](https://pandas-profiling.ydata.ai/docs/master/pages/integrations/data_apps.html) | Embedding profiling reports in [Streamlit](http://streamlit.io), [Dash](http://dash.plotly.com) or [Panel](https://panel.holoviz.org) applications |
+| [Pipelines](https://pandas-profiling.ydata.ai/docs/master/pages/integrations/pipelines.html) | Integration with DAG workflow execution tools like [Airflow](https://airflow.apache.org) or [Kedro](https://kedro.org) |
+| [Cloud services](https://pandas-profiling.ydata.ai/docs/master/pages/integrations/cloud_services.html) | Using `pandas-profiling` in hosted computation services like [Lambda](https://lambdalabs.com), [Google Cloud](https://github.com/GoogleCloudPlatform/analytics-componentized-patterns/blob/master/retail/propensity-model/bqml/bqml_kfp_retail_propensity_to_purchase.ipynb) or [Kaggle](https://www.kaggle.com/code) |
+| [IDEs](https://pandas-profiling.ydata.ai/docs/master/pages/integrations/ides.html) | Using `pandas-profiling` directly from integrated development environments such as [PyCharm](https://www.jetbrains.com/pycharm/) |
+
+## Support
+Need help? Want to share a perspective? Want to report a bug? Ideas for collaborations? Reach out via the following channels:
+
+- [Stack Overflow](https://stackoverflow.com/questions/tagged/pandas-profiling): ideal for asking questions on how to use the package
+- [Github Issues](https://github.com/ydataai/pandas-profiling/issues): bugs, proposals for change, feature requests
+- [Slack](https://slack.datacentricai.community): general chat, questions, collaboration
+- [Email](mailto:developers@ydata.ai): project collaborations or sponsoring
+
+> ❗ Before reporting an issue, check out [Common Issues](https://pandas-profiling.ydata.ai/docs/master/pages/support_contrib/common_issues.html).
+
+---
+## Contributing
+
+Learn how to get involved in the [Contribution Guide](https://pandas-profiling.ydata.ai/docs/master/pages/support_contrib/contribution_guidelines.html).
+
+A low-threshold place to ask questions or start contributing is the [Data Centric AI Community's Slack](https://slack.datacentricai.community).
+
+Contributors:
+
+<a href="https://github.com/ydataai/pandas-profiling/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=ydataai/pandas-profiling" />
+</a>

--- a/README.md
+++ b/README.md
@@ -43,13 +43,11 @@ The report contains three additional sections:
 - **Reproduction**: technical details about the analysis (time, version and configuration)
 
 
-> ⚡ Looking for a Spark backend to profile large datasets? WIP, track progress [here](https://github.com/ydataai/pandas-profiling/projects/3).
+> ⚡ Looking for a Spark backend to profile large datasets? It's WIP. Track progress [here](https://github.com/ydataai/pandas-profiling/projects/3).
 > 
 > ⌛ Interested in uncovering temporal patterns? Check out [popmon](https://github.com/ing-bank/popmon).
 
----
-
-## Quickstart
+## ▶️ Quickstart
 
 Start by loading your pandas `DataFrame` as you normally would, e.g. by using:
 
@@ -89,7 +87,7 @@ profile.to_notebook_iframe()
 
 ### Exporting the report to a file
 
-To generate a HTML report file, save the ProfileReport to an object and use the to_file() function:
+To generate a HTML report file, save the `ProfileReport` to an object and use the `to_file()` function:
 
 ```python
 profile.to_file("your_report.html")
@@ -107,15 +105,15 @@ profile.to_file("your_report.json")
 
 ### Command line usage
 
-For standard formatted CSV files (which can be read directly by pandas without additional settings), the pandas_profiling executable can be used in the command line. The example below generates a report named Example Profiling Report, using a configuration file called default.yaml, in the file report.html by processing a data.csv dataset.
+For standard formatted CSV files (which can be read directly by pandas without additional settings), the `pandas_profiling` executable can be used in the command line. The example below generates a report named _Example Profiling Report_, using a configuration file called `default.yaml`, in the file `report.html` by processing a `data.csv` dataset.
 
 ```sh
 pandas_profiling --title "Example Profiling Report" --config_file default.yaml data.csv report.html
 ```
 
-Additional details on the CLI [on the documentation](https://pandas-profiling.ydata.ai/docs/master/pages/getting_started/quickstart.html#command-line-usage).
+Additional details on the CLI are available [on the documentation](https://pandas-profiling.ydata.ai/docs/master/pages/getting_started/quickstart.html#command-line-usage).
 
-## Examples
+## 👀 Examples
 
 The following example reports showcase the potentialities of the package across a wide range of dataset and data types:
 
@@ -131,9 +129,9 @@ The following example reports showcase the potentialities of the package across 
 * [Website Inaccessibility](https://pandas-profiling.ydata.ai/examples/master/features/website_inaccessibility_report.html) (website accessibility analysis, showcasing support for URL data)
 * [Orange prices](https://pandas-profiling.ydata.ai/examples/master/features/united_report.html) and [Coal prices](https://pandas-profiling.ydata.ai/examples/master/features/flatly_report.html) (simple pricing evolution datasets, showcasing the theming options)
 
-## Installation
+## 🛠️ Installation
 
-Additional details, including information about widgets, are available [on the documentation](https://pandas-profiling.ydata.ai/docs/master/pages/getting_started/installation.html).
+Additional details, including information about widget support, are available [on the documentation](https://pandas-profiling.ydata.ai/docs/master/pages/getting_started/installation.html).
 
 ### Using pip
 [![PyPi Downloads](https://pepy.tech/badge/pandas-profiling)](https://pepy.tech/project/pandas-profiling)
@@ -167,9 +165,9 @@ Install by navigating to the proper directory and running:
 python setup.py install
 ```
 
-The profile report is written in HTML and CSS, which means `pandas-profiling` requires a modern browser. 
+The profile report is written in HTML and CSS, which means a modern browser is required. 
 
-You need [Python 3](https://python3statement.org/) to run this package. Other dependencies can be found in the requirements files:
+You need [Python 3](https://python3statement.org/) to run the package. Other dependencies can be found in the requirements files:
 
 | Filename | Requirements|
 |----------|-------------|
@@ -178,7 +176,7 @@ You need [Python 3](https://python3statement.org/) to run this package. Other de
 | [requirements-test.txt](https://github.com/ydataai/pandas-profiling/blob/master/requirements-test.txt) | Requirements for testing|
 | [setup.py](https://github.com/ydataai/pandas-profiling/blob/master/setup.py) | Requirements for widgets etc. |
 
-## Use cases
+## 📝 Use cases
 
 The documentation includes guides, tips and tricks for tackling commmon use cases:
 
@@ -186,41 +184,34 @@ The documentation includes guides, tips and tricks for tackling commmon use case
 |---|---|
 | [Profiling large datasets](https://pandas-profiling.ydata.ai/docs/master/pages/use_cases/big_data.html ) | Tips on how to prepare data and configure `pandas-profiling` for working with large datasets |
 | [Handling sensitive data](https://pandas-profiling.ydata.ai/docs/master/pages/use_cases/sensitive_data.html ) | Generating reports which are mindful about sensitive data in the input dataset |
-| [Dataset metadata and data dictionaries](https://pandas-profiling.ydata.ai/docs/master/pages/use_cases/metadata.html) | Embedding overall dataset details and column-specific data dictionary for easier sharing |
-| [Customizing the report's appearance](https://pandas-profiling.ydata.ai/docs/master/pages/use_cases/custom_report_appearance.html ) | Personalising the appearance of the report's page and of its plots |
+| [Dataset metadata and data dictionaries](https://pandas-profiling.ydata.ai/docs/master/pages/use_cases/metadata.html) | Complementing the report with dataset details and column-specific data dictionaries |
+| [Customizing the report's appearance](https://pandas-profiling.ydata.ai/docs/master/pages/use_cases/custom_report_appearance.html ) | Changing the appearance of the report's page and of the contained visualizations |
 
-## Integrations
+## 🔗 Integrations
 
-To maximize its usefulness in real world contexts, `pandas-profiling` has a set of implicit and explicit integration with a variety of other actors in the Data Science ecosystem: 
+To maximize its usefulness in real world contexts, `pandas-profiling` has a set of implicit and explicit integrations with a variety of other actors in the Data Science ecosystem: 
 
 | Integration type | Description |
 |---|---|
-| [Other DataFrame libraries](https://pandas-profiling.ydata.ai/docs/master/pages/integrations/other_dataframe_libraries.html) | How to compute the profiling of data stored in libraries different than pandas |
-| [Great Expectations](https://pandas-profiling.ydata.ai/docs/master/pages/integrations/great_expectations.html) | Generating [Great Expectations](https://greatexpectations.io) expectations suites straight from a profiling report |
+| [Other DataFrame libraries](https://pandas-profiling.ydata.ai/docs/master/pages/integrations/other_dataframe_libraries.html) | How to compute the profiling of data stored in libraries other than pandas |
+| [Great Expectations](https://pandas-profiling.ydata.ai/docs/master/pages/integrations/great_expectations.html) | Generating [Great Expectations](https://greatexpectations.io) expectations suites directly from a profiling report |
 | [Interactive applications](https://pandas-profiling.ydata.ai/docs/master/pages/integrations/data_apps.html) | Embedding profiling reports in [Streamlit](http://streamlit.io), [Dash](http://dash.plotly.com) or [Panel](https://panel.holoviz.org) applications |
 | [Pipelines](https://pandas-profiling.ydata.ai/docs/master/pages/integrations/pipelines.html) | Integration with DAG workflow execution tools like [Airflow](https://airflow.apache.org) or [Kedro](https://kedro.org) |
 | [Cloud services](https://pandas-profiling.ydata.ai/docs/master/pages/integrations/cloud_services.html) | Using `pandas-profiling` in hosted computation services like [Lambda](https://lambdalabs.com), [Google Cloud](https://github.com/GoogleCloudPlatform/analytics-componentized-patterns/blob/master/retail/propensity-model/bqml/bqml_kfp_retail_propensity_to_purchase.ipynb) or [Kaggle](https://www.kaggle.com/code) |
 | [IDEs](https://pandas-profiling.ydata.ai/docs/master/pages/integrations/ides.html) | Using `pandas-profiling` directly from integrated development environments such as [PyCharm](https://www.jetbrains.com/pycharm/) |
 
-## Support
-Need help? Want to share a perspective? Want to report a bug? Ideas for collaborations? Reach out via the following channels:
+## 🙋 Support
+Need help? Want to share a perspective? Report a bug? Ideas for collaborations? Reach out via the following channels:
 
 - [Stack Overflow](https://stackoverflow.com/questions/tagged/pandas-profiling): ideal for asking questions on how to use the package
-- [Github Issues](https://github.com/ydataai/pandas-profiling/issues): bugs, proposals for change, feature requests
-- [Slack](https://slack.datacentricai.community): general chat, questions, collaboration
+- [GitHub Issues](https://github.com/ydataai/pandas-profiling/issues): bugs, proposals for changes, feature requests
+- [Slack](https://slack.datacentricai.community): general chat, questions, collaborations
 - [Email](mailto:developers@ydata.ai): project collaborations or sponsoring
 
-> ❗ Before reporting an issue, check out [Common Issues](https://pandas-profiling.ydata.ai/docs/master/pages/support_contrib/common_issues.html).
+> ❗ Before reporting an issue on GitHub, check out [Common Issues](https://pandas-profiling.ydata.ai/docs/master/pages/support_contrib/common_issues.html).
 
----
-## Contributing
+## 🤝🏽 Contributing
 
 Learn how to get involved in the [Contribution Guide](https://pandas-profiling.ydata.ai/docs/master/pages/support_contrib/contribution_guidelines.html).
 
 A low-threshold place to ask questions or start contributing is the [Data Centric AI Community's Slack](https://slack.datacentricai.community).
-
-Contributors:
-
-<a href="https://github.com/ydataai/pandas-profiling/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=ydataai/pandas-profiling" />
-</a>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 </p>
 
-`pandas-profiling` generates profile reports from a pandas `DataFrame`. The pandas `df.describe()` function is handy yet a little basic for exploratory data analysis. `pandas-profiling` extends pandas DataFrame with `df.profile_report()`, which automatically generates a standardized univariate and multivariate report for data understanding.
+`pandas-profiling` generates profile reports from a pandas `DataFrame`. The pandas `df.describe()` function is handy yet a little basic for exploratory data analysis. `pandas-profiling` extends pandas `DataFrame` with `df.profile_report()`, which automatically generates a standardized univariate and multivariate report for data understanding.
 
 For each column, the following information (whenever relevant for the column type) is presented in an interactive HTML report:
 
@@ -43,7 +43,7 @@ The report contains three additional sections:
 - **Reproduction**: technical details about the analysis (time, version and configuration)
 
 
-> ⚡ Looking for a Spark backend to profile large datasets? It's WIP. Track progress [here](https://github.com/ydataai/pandas-profiling/projects/3).
+> ⚡ Looking for a Spark backend to profile large datasets? It's [work in progress](https://github.com/ydataai/pandas-profiling/projects/3).
 > 
 > ⌛ Interested in uncovering temporal patterns? Check out [popmon](https://github.com/ing-bank/popmon).
 
@@ -103,7 +103,7 @@ json_data = profile.to_json()
 profile.to_file("your_report.json")
 ```
 
-### Command line usage
+### Using in the command line
 
 For standard formatted CSV files (which can be read directly by pandas without additional settings), the `pandas_profiling` executable can be used in the command line. The example below generates a report named _Example Profiling Report_, using a configuration file called `default.yaml`, in the file `report.html` by processing a `data.csv` dataset.
 
@@ -157,15 +157,15 @@ conda install -c conda-forge pandas-profiling
 
 ### From source (development)
 
-Download the source code by cloning the repository or by clicking on ['Download ZIP'](https://github.com/ydataai/pandas-profiling/archive/master.zip).
+Download the source code by cloning the repository or click on [Download ZIP](https://github.com/ydataai/pandas-profiling/archive/master.zip) to download the latest stable version.
 
-Install by navigating to the proper directory and running:
+Install it by navigating to the proper directory and running:
 
 ```sh
 python setup.py install
 ```
 
-The profile report is written in HTML and CSS, which means a modern browser is required. 
+The profiling report is written in HTML and CSS, which means a modern browser is required. 
 
 You need [Python 3](https://python3statement.org/) to run the package. Other dependencies can be found in the requirements files:
 

--- a/docsrc/source/pages/getting_started/overview.rst
+++ b/docsrc/source/pages/getting_started/overview.rst
@@ -26,7 +26,7 @@ Overview
   :target: https://github.com/python/black
 
 ``pandas-profiling`` generates profile reports from a pandas ``DataFrame``.
-The pandas ``df.describe()`` function is handy yet a little basic for exploratory data analysis. ``pandas_profiling`` extends pandas DataFrame with ``df.profile_report()``,  
+The pandas ``df.describe()`` function is handy yet a little basic for exploratory data analysis. ``pandas-profiling`` extends pandas ``DataFrame`` with ``df.profile_report()``,  
 which automatically generates a standardized univariate and multivariate report for data understanding. 
 
 For each column, the following information (whenever relevant for the column type) is presented in an interactive HTML report:

--- a/docsrc/source/pages/integrations/cloud_services.rst
+++ b/docsrc/source/pages/integrations/cloud_services.rst
@@ -16,7 +16,7 @@ Lambda GPU Cloud
 Google Cloud
 ------------
 
-The Google Cloud Platform documentation features an article that uses ``pandas-profiling``. You can check it here: `Building a propensity model for financial services on Google Cloud <https://cloud.google.com/solutions/building-a-propensity-model-for-financial-services-on-gcp>`_.
+The Google Cloud Platform documentation features an article that uses ``pandas-profiling``. You can check it here: `Building a propensity model for financial services on Google Cloud <https://github.com/GoogleCloudPlatform/analytics-componentized-patterns/blob/master/retail/propensity-model/bqml/bqml_kfp_retail_propensity_to_purchase.ipynb>`_.
 
 Kaggle
 ------


### PR DESCRIPTION
**This PR:**

- Simplifies the `README.md` structure and contents:
    - Overview
    - ▶️ Quickstart
    - 👀 Examples
    - 🛠️ Installation
    - 📝 Use cases
    - 🔗 Integrations
    - 🙋 Support
    - 🤝🏽 Contributing
- Brings content more in line with the updated documentation
- Tries to surface the most relevant content (lowering time-to-value of the page, particularly to newcomers) and defers everything else to the documentation (instead of including the content)
- Fixes a link to the Google Cloud Platform example using `pandas-profiling` in the docs (previous link was broken, resource was found on a notebook on GCP's GitHub)

As usual, in some aspects an opinionated take, so happy to rollback some of the changes after discussion.

A live version of the updated README.md [is available here](https://github.com/ydataai/pandas-profiling/tree/docs/readme-improvements).