### PR TITLE
JSON encode of non-finite floats

### DIFF
--- a/src/pandas_profiling/config.py
+++ b/src/pandas_profiling/config.py
@@ -180,6 +180,16 @@ class Html(BaseModel):
     full_width: bool = False
 
 
+# Describes how non-finite numbers (such as NaN or Infinity) should be encoded in the JSON output
+class JsonNonFiniteEncoding(Enum):
+    # Use the default python behaviour, which violates the official JSON standard
+    PYTHON_NATIVE = 0
+    # Encode non-finite numbers as null values
+    NULL = 1
+    # Encode non-finite numbers as null values
+    STRING = 2
+
+
 class Duplicates(BaseModel):
     head: int = 10
     key: str = "# duplicates"
@@ -292,6 +302,9 @@ class Settings(BaseSettings):
     n_obs_unique: int = 10
     n_freq_table_max: int = 10
     n_extreme_obs: int = 10
+
+    # JSON output
+    json_non_finite_encoding: JsonNonFiniteEncoding = JsonNonFiniteEncoding.NULL
 
     # Report rendering
     report: Report = Report()

--- a/src/pandas_profiling/profile_report.py
+++ b/src/pandas_profiling/profile_report.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import math
 import warnings
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
@@ -10,7 +11,13 @@ import yaml
 from tqdm.auto import tqdm
 from visions import VisionsTypeset
 
-from pandas_profiling.config import Config, PandasSettings, Settings, SparkSettings
+from pandas_profiling.config import (
+    Config,
+    PandasSettings,
+    Settings,
+    SparkSettings,
+    JsonNonFiniteEncoding
+)
 from pandas_profiling.expectations_report import ExpectationsReport
 from pandas_profiling.model.alerts import AlertType
 from pandas_profiling.model.describe import describe as describe_df
@@ -335,8 +342,26 @@ class ProfileReport(SerializeReport, ExpectationsReport):
             if isinstance(o, dict):
                 return {encode_it(k): encode_it(v) for k, v in o.items()}
             else:
-                if isinstance(o, (bool, int, float, str)):
+                if isinstance(o, (bool, int, str)):
                     return o
+                elif isinstance(o, float):
+                    if not math.isfinite(o):
+                        # Special handling for non-finite floats.
+                        # This is necessary because JSON does not support NaN/Infinity values.
+                        # The default in Python is to generate invalid JSON.
+                        # Depending on the configuration, we can encode them as null values,
+                        # stringify the non-finite value, or output it as is to keep the default
+                        # Python behaviour.
+                        if self.config.json_non_finite_encoding == JsonNonFiniteEncoding.NULL:
+                            print(self.config.json_non_finite_encoding)
+                            return None
+                        elif self.config.json_non_finite_encoding == JsonNonFiniteEncoding.STRING:
+                            print(self.config.json_non_finite_encoding)
+                            return str(o)
+                        else:
+                            return o
+                    else:
+                        return o
                 elif isinstance(o, list):
                     return [encode_it(v) for v in o]
                 elif isinstance(o, set):


### PR DESCRIPTION
As described in #983, the JSON output is currently generating invalid JSON when non-finite floats (like NaN or Infinity) are included.

As @sbrugman suggested, I added a config option to switch between three behaviours:

- `PYTHON_NATIVE`: Use Python's default behaviour and generate the invalid JSON (as before)
- `NULL`: Encode non-finite numbers as null values.
- `STRING`: Stringify non-finite numbers (for example, NaN becomes the string "nan")

I made the null output the new default because it seems less surprising to encounter a null value when parsing numbers in the JSON compared to a  "nan" string. I see that there is also an argument to make the old behaviour the default, to ensure 100% compatibility with existing code. Please let me know what you think should be the default.

## Summary of the changes

- I added an enum `JsonNonFiniteEncoding` with the three options listed above
- I added an `json_non_finite_encoding` field in the `Settings` class
- In the `encode_it` method that already manages the JSON-encoding of all values, I added special handling for non-finite floats, which encodes the values according to the configuration.

The changes should not break anything except that the JSON output will now contain null values instead of the raw "NaN" entries that violate the standard.

## Example usage

```python
import pandas as pd
from pandas_profiling import ProfileReport
from pandas_profiling.config import Settings, JsonNonFiniteEncoding

df = pd.DataFrame([1, 1, 1], columns=["a"])

profile = ProfileReport(df, title="Pandas Profiling Report", minimal=True)

profile.config.json_non_finite_encoding = JsonNonFiniteEncoding.STRING

print(profile.to_json())
```

Gives the following output:

```
[...]
"kurtosis": "nan",
[...]
```

When choosing the `NULL` config option, it would be:

```
"kurtosis": null,
```

And with the `PYTHON_NATIVE` option it would be:

```
"kurtosis": NaN,
```