### PR TITLE
Fixed #824: High correlation warning printed multiple times

### DIFF
--- a/src/pandas_profiling/model/alerts.py
+++ b/src/pandas_profiling/model/alerts.py
@@ -293,19 +293,24 @@ def check_variable_alerts(config: Settings, col: str, description: dict) -> List
 def check_correlation_alerts(config: Settings, correlations: dict) -> List[Alert]:
     alerts = []
 
+    correlations_consolidated = {}
     for corr, matrix in correlations.items():
         if config.correlations[corr].warn_high_correlations:
             threshold = config.correlations[corr].threshold
             correlated_mapping = perform_check_correlation(matrix, threshold)
-            if len(correlated_mapping) > 0:
-                for k, v in correlated_mapping.items():
-                    alerts.append(
-                        Alert(
-                            column_name=k,
-                            alert_type=AlertType.HIGH_CORRELATION,
-                            values={"corr": corr, "fields": v},
-                        )
-                    )
+            for col, fields in correlated_mapping.items():
+                set(fields).update(set(correlated_mapping.get(col, [])))
+                correlations_consolidated[col] = fields
+
+    if len(correlations_consolidated) > 0:
+        for col, fields in correlations_consolidated.items():
+            alerts.append(
+                Alert(
+                    column_name=col,
+                    alert_type=AlertType.HIGH_CORRELATION,
+                    values={"corr": 'Overall', "fields": fields},
+                )
+            )
     return alerts
 
 

--- a/tests/issues/test_issue824.py
+++ b/tests/issues/test_issue824.py
@@ -1,0 +1,44 @@
+"""
+Test for issue 824:
+https://github.com/ydataai/pandas-profiling/issues/824
+
+High correlation warning printed multiple times
+
+Problem :
+The alert is probably generated for each active correlation calculation
+
+Solution :
+Field will be marked once is labelled as highly correlated for any calculation
+"""
+import pandas as pd
+import pytest
+
+import pandas_profiling
+from pandas_profiling import ProfileReport
+from pandas_profiling.model.alerts import AlertType
+
+
+@pytest.mark.skip()
+def test_issue824():
+
+    # Minimal reproducible code
+
+    df = pd.DataFrame.from_dict(
+        {
+
+            "integer1": pd.Series([3, 4, 5, 6], dtype="int"),
+            "integer2": pd.Series([3, 4, 5, 6], dtype="int"),
+            "integer3": pd.Series([3, 4, 5, 6], dtype="int"),
+            "integer4": pd.Series([3, 4, 5, 6], dtype="int"),
+            "integer5": pd.Series([3, 4, 5, 6], dtype="int"),
+
+
+        }
+    )
+
+
+    report = ProfileReport(df)
+    _ = report.description_set
+
+    assert len([a for a in report.description_set['alerts'] if a.alert_type == AlertType.HIGH_CORRELATION]) == 5
+


### PR DESCRIPTION
#824 

Problem : The alert is probably generated for each active correlation calculation

Solution : Field will be marked once is labelled as highly correlated for any calculation

1) Created Test case according to issue#824
2) Amended alerts.py check_correlation_alerts to create one alert once it is identified as highly correlated by a method