### PR TITLE
Support all numeric data types in spark

### DIFF
--- a/src/pandas_profiling/model/spark/summary_spark.py
+++ b/src/pandas_profiling/model/spark/summary_spark.py
@@ -51,7 +51,11 @@ def spark_describe_1d(
         vtype = {
             "IntegerType": "Numeric",
             "LongType": "Numeric",
+            "ShortType": "Numeric",
+            "ByteType": "Numeric",
             "DoubleType": "Numeric",
+            "FloatType": "Numeric",
+            "DecimalType": "Numeric",
             "StringType": "Categorical",
             "ArrayType": "Categorical",
             "BooleanType": "Boolean",


### PR DESCRIPTION
The Spark version of pandas-profiling did not support some numerical Spark data types yet: short, byte, float and decimal.

This adds support for the missing numerical types.