### PR TITLE
fix: pandas groupby ignoring duplicates with nans

### DIFF
--- a/src/pandas_profiling/model/pandas/duplicates_pandas.py
+++ b/src/pandas_profiling/model/pandas/duplicates_pandas.py
@@ -35,7 +35,7 @@ def pandas_get_duplicates(
             duplicated_rows = df.duplicated(subset=supported_columns, keep=False)
             duplicated_rows = (
                 df[duplicated_rows]
-                .groupby(supported_columns)
+                .groupby(supported_columns, dropna=False)
                 .size()
                 .reset_index(name=duplicates_key)
             )


### PR DESCRIPTION
Fixes #1012 
It is a bug with the pandas groupby (which is used to showcase examples of duplicated rows) that does not consider the missing values.