### PR TITLE
feat: add sortby parameter to timeseries mode

### DIFF
--- a/src/pandas_profiling/config.py
+++ b/src/pandas_profiling/config.py
@@ -93,6 +93,7 @@ class UrlVars(BaseModel):
 
 class TimeseriesVars(BaseModel):
     active: bool = False
+    sortby: Optional[str] = None
     autocorrelation: float = 0.7
     lags: List[int] = [1, 7, 12, 24, 30]
     significance: float = 0.05

--- a/src/pandas_profiling/profile_report.py
+++ b/src/pandas_profiling/profile_report.py
@@ -54,6 +54,7 @@ class ProfileReport(SerializeReport, ExpectationsReport):
         dark_mode: bool = False,
         orange_mode: bool = False,
         tsmode: bool = False,
+        sortby: Optional[str] = None,
         sample: Optional[dict] = None,
         config_file: Union[Path, str] = None,
         lazy: bool = True,
@@ -104,10 +105,12 @@ class ProfileReport(SerializeReport, ExpectationsReport):
             report_config = report_config.update(Config.get_arg_groups("orange_mode"))
         if tsmode:
             report_config = report_config.update(Config.get_arg_groups("tsmode"))
+            if sortby:
+                report_config.vars.timeseries.sortby = sortby
         if len(kwargs) > 0:
             report_config = report_config.update(Config.shorthands(kwargs))
 
-        self.df = df
+        self.df = self.__initialize_dataframe(df, report_config)
         self.config = report_config
         self._df_hash = None
         self._sample = sample
@@ -117,6 +120,21 @@ class ProfileReport(SerializeReport, ExpectationsReport):
         if not lazy:
             # Trigger building the report structure
             _ = self.report
+
+    @staticmethod
+    def __initialize_dataframe(
+        df: Optional[pd.DataFrame], report_config: Settings
+    ) -> Optional[pd.DataFrame]:
+        if (
+            df is not None
+            and report_config.vars.timeseries.active
+            and report_config.vars.timeseries.sortby
+        ):
+            return df.sort_values(by=report_config.vars.timeseries.sortby).reset_index(
+                drop=True
+            )
+        else:
+            return df
 
     def invalidate_cache(self, subset: Optional[str] = None) -> None:
         """Invalidate report cache. Useful after changing setting.


### PR DESCRIPTION
Add a parameter to sort the data frame for time-series, the parameter is only used if the `tsmode` is active.
```python
profile = ProfileReport(df, tsmode=True, sortby="<column_name>")
```