### PR TITLE
feat: add augmented dickey fuller test to stat tab

### DIFF
--- a/src/pandas_profiling/report/structure/variables/render_timeseries.py
+++ b/src/pandas_profiling/report/structure/variables/render_timeseries.py
@@ -219,6 +219,10 @@ def render_timeseries(config: Settings, summary: dict) -> dict:
                 "name": "Monotonicity",
                 "value": fmt_monotonic(summary["monotonic"]),
             },
+            {
+                "name": "Augmented Dickey-Fuller test p-value",
+                "value": fmt_numeric(summary["addfuller"]),
+            },
         ],
         name="Descriptive statistics",
     )


### PR DESCRIPTION
add the statistic test for stationarity to the descriptive statistics tab

![image](https://user-images.githubusercontent.com/9274404/187899746-02327fa8-7356-40b0-865c-e9769eab065e.png)
