### PR TITLE
fix: get basic example working again

### DIFF
--- a/src/pandas_profiling/model/handler.py
+++ b/src/pandas_profiling/model/handler.py
@@ -62,11 +62,11 @@ def get_render_map() -> Dict[str, Callable]:
     import pandas_profiling.report.structure.variables as render_algorithms
 
     render_map = {
-        "Boolean": render_algorithms.render_boolean,
+        # "Boolean": render_algorithms.render_boolean,
         "Numeric": render_algorithms.render_real,
         "Complex": render_algorithms.render_complex,
         "DateTime": render_algorithms.render_date,
-        "Categorical": render_algorithms.render_categorical,
+        # "Categorical": render_algorithms.render_categorical,
         "URL": render_algorithms.render_url,
         "Path": render_algorithms.render_path,
         "File": render_algorithms.render_file,

--- a/src/pandas_profiling/report/structure/variables/render_boolean.py
+++ b/src/pandas_profiling/report/structure/variables/render_boolean.py
@@ -90,16 +90,12 @@ def render_boolean(config: Settings, summary: dict) -> dict:
     ]
 
     max_unique = config.plot.pie.max_unique
-    show = config.plot.cat_freq.show=======
+    show = config.plot.cat_freq.show()
 
     if show and (max_unique > 0):
         items.append(
             Image(
-                cat_frequency_plot(
-                    config,
-                    summary["value_counts_without_nan"]
-                    legend_kws={"loc": "upper right"},
-                ),
+                cat_frequency_plot(config, summary["value_counts"]),
                 image_format=image_format,
                 alt="Category Frequency Plot",
                 name="Category Frequency Plot",

--- a/src/pandas_profiling/report/structure/variables/render_categorical.py
+++ b/src/pandas_profiling/report/structure/variables/render_categorical.py
@@ -410,7 +410,7 @@ def render_categorical(config: Settings, summary: dict) -> dict:
             Image(
                 cat_frequency_plot(
                     config,
-                    summary["value_counts_without_nan"],
+                    summary["value_counts"],
                 ),
                 image_format=image_format,
                 alt="Category Frequency Plot",

--- a/venv/spark.yml
+++ b/venv/spark.yml
@@ -1,0 +1,23 @@
+name: spark-env
+
+channels:
+  - conda-forge
+  - defaults
+
+dependencies:
+  - python=3.9
+  - ipykernel
+  - nb_conda
+  - jupyterlab
+  - jupyterlab_code_formatter
+  - isort
+  - black
+  - pyspark=3.2.0
+  - pip
+  - matplotlib
+  - pip:
+    - delta-spark==1.2.1
+    - -r requirements-dev.txt
+    - -r requirements-pandas.txt
+    - -r requirements.txt
+    - -r requirements-spark.txt


### PR DESCRIPTION
#### Context

After latest develop changes and a long time since the last merge with develop, the latest develop merge has killed the spark-branch. These are a bunch of minimal fixes to get it working again

#### Changes

Fix merge conflicts
Disabled boolean rendering [to be fixed later]
Disabled categorical rendering [to be fixed later]

Guide for building and testing spark-profiling can be found [here](https://github.com/ydataai/pandas-profiling/wiki)