### PR TITLE
fix: make tangled-up-in-unicode an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,22 @@ Additional details, including information about widget support, are available [o
 You can install using the `pip` package manager by running:
 
 ```sh
-pip install -U pandas-profiling[notebook]
+pip install -U pandas-profiling
 ```
+
+#### Extras
+
+The package declares "extras", sets of additional dependencies.
+
+* `[notebook]`: support for rendering the report in Jupyter notebook widgets.
+* `[unicode]`: support for more detailed Unicode analysis, at the expense of additional disk space.
+
+Install these with e.g.
+
+```sh
+pip install -U pandas-profiling[notebook,unicode]
+```
+
 
 ### Using conda
 [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pandas-profiling.svg)](https://anaconda.org/conda-forge/pandas-profiling)

--- a/docsrc/source/pages/getting_started/installation.rst
+++ b/docsrc/source/pages/getting_started/installation.rst
@@ -21,8 +21,7 @@ You can install using the ``pip`` package manager by running:
 
 .. code-block:: console
 
-    pip install -U pandas-profiling[notebook]
-    jupyter nbextension enable --py widgetsnbextension
+    pip install -U pandas-profiling
 
 If you are in a notebook (locally, LambdaLabs, Google Colab or Kaggle), you can run:
 
@@ -65,7 +64,8 @@ This can be done via ``pip``:
 
 .. code-block::
 
-  pip install ipywidgets
+  pip install pandas-profiling[notebook]
+  jupyter nbextension enable --py widgetsnbextension
 
 Or via ``conda``: 
 
@@ -91,3 +91,17 @@ This can also be done via the following one-liner:
 .. code-block:: console
 
     pip install https://github.com/ydataai/pandas-profiling/archive/master.zip
+
+Extras
+------
+
+The package declares some "extras", sets of additional dependencies.
+
+* ``[notebook]``: support for rendering the report in Jupyter notebook widgets.
+* ``[unicode]``: support for more detailed Unicode analysis, at the expense of additional disk space.
+
+Install these with e.g.
+
+.. code-block:: console
+
+    pip install -U pandas-profiling[notebook,unicode]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,6 @@ htmlmin==0.1.12
 missingno>=0.4.2, <0.6
 # Correlations
 phik>=0.11.1,<0.13
-# Text analysis
-tangled-up-in-unicode==0.2.0
 # Examples
 requests>=2.24.0, <2.29
 # Progress bar

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,9 @@ setup(
             "jupyter-core>=4.6.3",
             "ipywidgets>=7.5.1",
         ],
+        "unicode": [
+            "tangled-up-in-unicode==0.2.0",
+        ],
     },
     package_data={
         "pandas_profiling": ["py.typed"],

--- a/src/pandas_profiling/model/pandas/describe_categorical_pandas.py
+++ b/src/pandas_profiling/model/pandas/describe_categorical_pandas.py
@@ -53,7 +53,14 @@ def counter_to_series(counter: Counter) -> pd.Series:
 
 
 def unicode_summary_vc(vc: pd.Series) -> dict:
-    from tangled_up_in_unicode import block, block_abbr, category, category_long, script
+    try:
+        from tangled_up_in_unicode import block, block_abbr, category, category_long, script
+    except ImportError:
+        from unicodedata import category
+        block = lambda char: "(unknown)"
+        block_abbr = lambda char: "(unknown)"
+        category_long = lambda char: "(unknown)"
+        script = lambda char: "(unknown)"
 
     # Unicode Character Summaries (category and script name)
     character_counts = get_character_counts_vc(vc)


### PR DESCRIPTION
Knowing the exact Unicode properties is likely not a priority for all users. Furthermore, unicodedata as of Python 3.10 is based on UCD 13, so the category data in there ought to be fairly recent.

This should probably be documented (as well as the `[unicode]` extra), but I'm not sure what the best place for it would be.

Refs https://github.com/dylan-profiler/tangled-up-in-unicode/issues/10 – importing `tangled` will create 2 gigabytes of 
bytecode files and takes a while.
