### PR TITLE
feat: introduce 'auto' parameter for correlations

### DIFF
--- a/docsrc/source/pages/advanced_usage/available_settings.rst
+++ b/docsrc/source/pages/advanced_usage/available_settings.rst
@@ -91,6 +91,7 @@ For instance, to disable all correlation computations (may be relevant for large
     profile = df.profile_report(
         title="Report without correlations",
         correlations={
+            "auto": {"calculate": False},
             "pearson": {"calculate": False},
             "spearman": {"calculate": False},
             "kendall": {"calculate": False},

--- a/docsrc/source/pages/reference/api/_autosummary/pandas_profiling.model.correlations.rst
+++ b/docsrc/source/pages/reference/api/_autosummary/pandas_profiling.model.correlations.rst
@@ -32,6 +32,7 @@
       Pearson
       PhiK
       Spearman
+      Auto
    
    
 

--- a/docsrc/source/pages/tables/config_correlations.csv
+++ b/docsrc/source/pages/tables/config_correlations.csv
@@ -14,3 +14,6 @@ Parameter,Type,Default,Description
 ``correlations.cramers.calculate``,boolean,``True``,"Whether to calculate this coefficient"
 ``correlations.cramers.warn_high_correlations``,boolean,``True``,"Show warning for correlations higher than the threshold"
 ``correlations.cramers.threshold``,float,0.9,"Warning threshold"
+``correlations.auto.calculate``,boolean,``True``,"Whether to calculate this coefficient"
+``correlations.auto.warn_high_correlations``,boolean,``True``,"Show warning for correlations higher than the threshold"
+``correlations.auto.threshold``,float,0.9,"Warning threshold"

--- a/src/pandas_profiling/config.py
+++ b/src/pandas_profiling/config.py
@@ -288,6 +288,7 @@ class Settings(BaseSettings):
     }
 
     correlations: Dict[str, Correlation] = {
+        "auto": Correlation(key="auto"),
         "spearman": Correlation(key="spearman"),
         "pearson": Correlation(key="pearson"),
         "kendall": Correlation(key="kendall"),
@@ -298,6 +299,7 @@ class Settings(BaseSettings):
     interactions: Interactions = Interactions()
 
     categorical_maximum_correlation_distinct: int = 100
+    discretization_n_bins: int = 10
     # Use `deep` flag for memory_usage
     memory_deep: bool = False
     plot: Plot = Plot()
@@ -378,6 +380,7 @@ class Config:
             "dendrogram": False,
         },
         "correlations": {
+            "auto": {"calculate": False},
             "pearson": {"calculate": False},
             "spearman": {"calculate": False},
             "kendall": {"calculate": False},

--- a/src/pandas_profiling/config_minimal.yaml
+++ b/src/pandas_profiling/config_minimal.yaml
@@ -111,6 +111,10 @@ correlations:
       calculate: false
       warn_high_correlations: true
       threshold: 0.9
+    auto:
+       calculate: true
+       warn_high_correlations: true
+       threshold: 0.9
 
 
 # Bivariate / Pairwise relations

--- a/src/pandas_profiling/model/correlations.py
+++ b/src/pandas_profiling/model/correlations.py
@@ -21,6 +21,13 @@ class Correlation:
         raise NotImplementedError()
 
 
+class Auto(Correlation):
+    @staticmethod
+    @multimethod
+    def compute(config: Settings, df: Sized, summary: dict) -> Optional[Sized]:
+        raise NotImplementedError()
+
+
 class Spearman(Correlation):
     @staticmethod
     @multimethod
@@ -71,7 +78,7 @@ def calculate_correlation(
     config: Settings, df: Sized, correlation_name: str, summary: dict
 ) -> Optional[Sized]:
     """Calculate the correlation coefficients between variables for the correlation types selected in the config
-    (pearson, spearman, kendall, phi_k, cramers).
+    (auto, pearson, spearman, kendall, phi_k, cramers).
 
     Args:
         config: report Settings object
@@ -87,6 +94,7 @@ def calculate_correlation(
         return None
 
     correlation_measures = {
+        "auto": Auto,
         "pearson": Pearson,
         "spearman": Spearman,
         "kendall": Kendall,

--- a/src/pandas_profiling/model/pandas/correlations_pandas.py
+++ b/src/pandas_profiling/model/pandas/correlations_pandas.py
@@ -9,11 +9,16 @@ from scipy import stats
 
 from pandas_profiling.config import Settings
 from pandas_profiling.model.correlations import (
+    Auto,
     Cramers,
     Kendall,
     Pearson,
     PhiK,
     Spearman,
+)
+from pandas_profiling.model.pandas.discretize_pandas import (
+    DiscretizationType,
+    Discretizer,
 )
 
 
@@ -67,22 +72,26 @@ def _cramers_corrected_stat(confusion_matrix: pd.DataFrame, correction: bool) ->
     return corr
 
 
+def _pairwise_spearman(col_1: pd.Series, col_2: pd.Series) -> float:
+    return col_1.corr(col_2, method="spearman")
+
+
+def _pairwise_cramers(col_1: pd.Series, col_2: pd.Series) -> float:
+    return _cramers_corrected_stat(pd.crosstab(col_1, col_2), correction=True)
+
+
 @Cramers.compute.register(Settings, pd.DataFrame, dict)
 def pandas_cramers_compute(
     config: Settings, df: pd.DataFrame, summary: dict
 ) -> Optional[pd.DataFrame]:
     threshold = config.categorical_maximum_correlation_distinct
 
-    # `index` and `columns` must not be a set since Pandas 1.5,
-    # so convert it to a list. The order of the list is arbitrary.
-    categoricals = list(
-        {
-            key
-            for key, value in summary.items()
-            if value["type"] in {"Categorical", "Boolean"}
-            and value["n_distinct"] <= threshold
-        }
-    )
+    categoricals = {
+        key
+        for key, value in summary.items()
+        if value["type"] in {"Categorical", "Boolean"}
+        and value["n_distinct"] <= threshold
+    }
 
     if len(categoricals) <= 1:
         return None
@@ -101,6 +110,51 @@ def pandas_cramers_compute(
             confusion_matrix, correction=True
         )
         correlation_matrix.loc[name1, name2] = correlation_matrix.loc[name2, name1]
+    return correlation_matrix
+
+
+@Auto.compute.register(Settings, pd.DataFrame, dict)
+def pandas_auto_compute(
+    config: Settings, df: pd.DataFrame, summary: dict
+) -> Optional[pd.DataFrame]:
+    threshold = config.categorical_maximum_correlation_distinct
+    n_bins = config.discretization_n_bins
+
+    numerical_columns = [
+        key for key, value in summary.items() if value["type"] == "Numeric"
+    ]
+    categorical_columns = [
+        key
+        for key, value in summary.items()
+        if value["type"] in {"Categorical", "Boolean"}
+        and value["n_distinct"] <= threshold
+    ]
+    df_discretized = Discretizer(
+        DiscretizationType.UNIFORM, n_bins=n_bins
+    ).discretize_dataframe(df)
+    columns_tested = numerical_columns + categorical_columns
+    correlation_matrix = pd.DataFrame(
+        np.ones((len(columns_tested), len(columns_tested))),
+        index=columns_tested,
+        columns=columns_tested,
+    )
+    for col_1_name, col_2_name in itertools.combinations(columns_tested, 2):
+
+        method = (
+            _pairwise_spearman
+            if col_1_name and col_2_name not in categorical_columns
+            else _pairwise_cramers
+        )
+
+        def f(x: str) -> pd.Series:
+            return df_discretized if x in numerical_columns else df
+
+        score = method(f(col_1_name)[col_1_name], f(col_2_name)[col_2_name])
+        (
+            correlation_matrix.loc[col_1_name, col_2_name],
+            correlation_matrix.loc[col_2_name, col_1_name],
+        ) = (score, score)
+
     return correlation_matrix
 
 

--- a/src/pandas_profiling/model/pandas/discretize_pandas.py
+++ b/src/pandas_profiling/model/pandas/discretize_pandas.py
@@ -1,0 +1,81 @@
+from enum import Enum
+from typing import List
+
+import numpy as np
+import pandas as pd
+
+
+class DiscretizationType(Enum):
+    UNIFORM = "uniform"
+    QUANTILE = "quantile"
+
+
+class Discretizer:
+    """
+    A class which enables the discretization of a pandas dataframe.
+    Perform this action when you want to convert a continuous variable
+    into a categorical variable.
+
+    Attributes:
+
+    method (DiscretizationType): this attribute controls how the buckets
+    of your discretization are formed. A uniform discretization type forms
+    the bins to be of equal width whereas a quantile discretization type
+    forms the bins to be of equal size.
+
+    n_bins (int): number of bins
+    reset_index (bool): instruction to reset the index of
+                        the dataframe after the discretization
+    """
+
+    def __init__(
+        self, method: DiscretizationType, n_bins: int = 10, reset_index: bool = False
+    ) -> None:
+        self.discretization_type = method
+        self.n_bins = n_bins
+        self.reset_index = reset_index
+
+    def discretize_dataframe(self, dataframe: pd.DataFrame) -> pd.DataFrame:
+        """_summary_
+
+        Args:
+            dataframe (pd.DataFrame): pandas dataframe
+
+        Returns:
+            pd.DataFrame: discretized dataframe
+        """
+
+        discretized_df = dataframe.copy()
+        all_columns = dataframe.columns
+        num_columns = self._get_numerical_columns(dataframe)
+        for column in num_columns:
+            discretized_df.loc[:, column] = self._discretize_column(
+                discretized_df[column]
+            )
+
+        discretized_df = discretized_df[all_columns]
+        return (
+            discretized_df.reset_index(drop=True)
+            if self.reset_index
+            else discretized_df
+        )
+
+    def _discretize_column(self, column: pd.Series) -> pd.Series:
+        if self.discretization_type == DiscretizationType.UNIFORM:
+            return self._descritize_quantile(column)
+
+        elif self.discretization_type == DiscretizationType.QUANTILE:
+            return self._descritize_uniform(column)
+
+    def _descritize_quantile(self, column: pd.Series) -> pd.Series:
+        return pd.qcut(
+            column, q=self.n_bins, labels=False, retbins=False, duplicates="drop"
+        ).values
+
+    def _descritize_uniform(self, column: pd.Series) -> pd.Series:
+        return pd.cut(
+            column, bins=self.n_bins, labels=False, retbins=True, duplicates="drop"
+        )[0].values
+
+    def _get_numerical_columns(self, dataframe: pd.DataFrame) -> List[str]:
+        return dataframe.select_dtypes(include=np.number).columns.tolist()

--- a/src/pandas_profiling/report/structure/correlations.py
+++ b/src/pandas_profiling/report/structure/correlations.py
@@ -55,12 +55,20 @@ def get_correlation_items(config: Settings, summary: dict) -> Optional[Renderabl
     The empirical estimators used for Cramér's V have been proved to be biased, even for large samples.
     We use a bias-corrected measure that has been proposed by Bergsma in 2013 that can be found <a href='http://stats.lse.ac.uk/bergsma/pdf/cramerV3.pdf'>here</a>."""
 
+    auto_description = """The auto setting is an easily interpretable pairwise column metric of the following mapping:
+                        vartype-vartype         : method, 
+                        categorical-categorical : Cramer's V, 
+                        numerical-categorical   : Cramer's V (using a discretized numerical column), 
+                        numerical-numerical     : Spearman's ρ. 
+                        This configuration uses the best metric for each pair of columns."""
+
     key_to_data = {
         "pearson": (-1, "Pearson's r", pearson_description),
         "spearman": (-1, "Spearman's ρ", spearman_description),
         "kendall": (-1, "Kendall's τ", kendall_description),
         "phi_k": (0, "Phik (φk)", phi_k_description),
         "cramers": (0, "Cramér's V (φc)", cramers_description),
+        "auto": (0, "Auto", auto_description),
     }
 
     image_format = config.plot.image_format

--- a/tests/unit/test_pandas/test_discretize.py
+++ b/tests/unit/test_pandas/test_discretize.py
@@ -1,0 +1,65 @@
+import pandas as pd
+
+from pandas_profiling.model.pandas.discretize_pandas import (
+    DiscretizationType,
+    Discretizer,
+)
+
+
+def test_discretize_quantile():
+    example_data = {
+        "height": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0],
+        "weight": [60.0, 70.0, 70.0, 80.0, 80.0, 80.0, 90.0, 90.0, 90.0, 90.0],
+    }
+    example_df = pd.DataFrame(example_data)
+    expected_labels = {
+        "height": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        "weight": [0, 1, 1, 3, 3, 3, 5, 5, 5, 5],
+    }
+
+    discretizer = Discretizer(method=DiscretizationType.QUANTILE, n_bins=10)
+    expected_labels_df = pd.DataFrame(expected_labels)
+
+    cut_bins = discretizer.discretize_dataframe(example_df)
+
+    assert expected_labels_df.to_numpy().all() == cut_bins.to_numpy().all()
+
+
+def test_discretize_uniform():
+    example_data = {
+        "height": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0],
+        "weight": [60.0, 70.0, 70.0, 80.0, 80.0, 80.0, 90.0, 90.0, 90.0, 90.0],
+    }
+    example_df = pd.DataFrame(example_data)
+
+    expected_labels = {
+        "height": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        "weight": [0, 3, 3, 6, 6, 6, 9, 9, 9, 9],
+    }
+    expected_labels_df = pd.DataFrame(expected_labels)
+    discretizer = Discretizer(method=DiscretizationType.QUANTILE, n_bins=10)
+
+    cut_bins = discretizer.discretize_dataframe(example_df)
+
+    assert expected_labels_df.to_numpy().all() == cut_bins.to_numpy().all()
+
+
+def test_mixed_discretization():
+    example_data = {
+        "height": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0],
+        "weight": [60.0, 70.0, 70.0, 80.0, 80.0, 80.0, 90.0, 90.0, 90.0, 90.0],
+        "char": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"],
+    }
+    example_df = pd.DataFrame(example_data)
+
+    expected_labels = {
+        "height": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        "weight": [0, 1, 1, 3, 3, 3, 5, 5, 5, 5],
+        "char": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"],
+    }
+    expected_labels_df = pd.DataFrame(expected_labels)
+    discretizer = Discretizer(method=DiscretizationType.UNIFORM, n_bins=10)
+
+    cut_bins = discretizer.discretize_dataframe(example_df)
+
+    assert expected_labels_df.to_numpy().all() == cut_bins.to_numpy().all()


### PR DESCRIPTION
The purpose of this feature is to automatically choose the most suitable 'correlation'/'association' metric for each pair of columns .The auto setting is an easily interpretable pairwise column metric that uses previously implemented metrics of the following mapping:
```
vartype-vartype             : method, 
categorical-categorical : Cramer's V, 
numerical-categorical   : Cramer's V (using a discretized numerical column), 
numerical-numerical     : Spearman's ρ. 
