### PR TITLE
fix: cramer's correlation fails with missing values

### DIFF
--- a/src/pandas_profiling/model/pandas/correlations_pandas.py
+++ b/src/pandas_profiling/model/pandas/correlations_pandas.py
@@ -97,9 +97,12 @@ def pandas_cramers_compute(
 
     for name1, name2 in itertools.combinations(categoricals, 2):
         confusion_matrix = pd.crosstab(df[name1], df[name2])
-        correlation_matrix.loc[name2, name1] = _cramers_corrected_stat(
-            confusion_matrix, correction=True
-        )
+        if confusion_matrix.empty:
+            correlation_matrix.loc[name2, name1] = np.nan
+        else:
+            correlation_matrix.loc[name2, name1] = _cramers_corrected_stat(
+                confusion_matrix, correction=True
+            )
         correlation_matrix.loc[name1, name2] = correlation_matrix.loc[name2, name1]
     return correlation_matrix
 


### PR DESCRIPTION
Fixes #1099.
Cramer's correlation fails when the contingency table between two columns is empty, this seems to be a frequent issue in cases where the columns have a high percentage of missing values.