### PR TITLE
fix: correlation `auto` passing extra parameters

### DIFF
--- a/src/pandas_profiling/model/correlations.py
+++ b/src/pandas_profiling/model/correlations.py
@@ -110,7 +110,6 @@ def calculate_correlation(
             config, df, summary
         )
     except (ValueError, AssertionError, TypeError, DataError, IndexError) as e:
-        import ipdb; ipdb.set_trace()
         warn_correlation(correlation_name, str(e))
 
     if correlation is not None and len(correlation) <= 0:

--- a/src/pandas_profiling/model/correlations.py
+++ b/src/pandas_profiling/model/correlations.py
@@ -25,7 +25,7 @@ class Auto(Correlation):
     @staticmethod
     @multimethod
     def compute(
-        config: Settings, df: Sized, summary: dict, n_bins: int
+        config: Settings, df: Sized, summary: dict
     ) -> Optional[Sized]:
         raise NotImplementedError()
 
@@ -110,6 +110,7 @@ def calculate_correlation(
             config, df, summary
         )
     except (ValueError, AssertionError, TypeError, DataError, IndexError) as e:
+        import ipdb; ipdb.set_trace()
         warn_correlation(correlation_name, str(e))
 
     if correlation is not None and len(correlation) <= 0:

--- a/src/pandas_profiling/model/pandas/correlations_pandas.py
+++ b/src/pandas_profiling/model/pandas/correlations_pandas.py
@@ -156,12 +156,11 @@ def pandas_phik_compute(
     return correlation
 
 
-@Auto.compute.register(Settings, pd.DataFrame, dict, int)
+@Auto.compute.register(Settings, pd.DataFrame, dict)
 def pandas_auto_compute(
     config: Settings,
     df: pd.DataFrame,
-    summary: dict,
-    n_bins: int = 10,
+    summary: dict
 ) -> Optional[pd.DataFrame]:
     threshold = config.categorical_maximum_correlation_distinct
 
@@ -175,7 +174,7 @@ def pandas_auto_compute(
         and value["n_distinct"] <= threshold
     ]
     df_discretized = Discretizer(
-        DiscretizationType.UNIFORM, n_bins=n_bins
+        DiscretizationType.UNIFORM, n_bins=config.correlations["auto"].n_bins
     ).discretize_dataframe(df)
     columns_tested = numerical_columns + categorical_columns
     correlation_matrix = pd.DataFrame(


### PR DESCRIPTION
Fix "Auto" correlation requiring extra configuration parameter `n_bins` which was already available through settings.