### PR TITLE
fix: pandas.DataFrame.iteritems() deprecated

### DIFF
--- a/src/pandas_profiling/model/pandas/summary_pandas.py
+++ b/src/pandas_profiling/model/pandas/summary_pandas.py
@@ -77,7 +77,7 @@ def pandas_get_series_descriptions(
     if pool_size <= 0:
         pool_size = multiprocessing.cpu_count()
 
-    args = [(name, series) for name, series in df.iteritems()]
+    args = [(name, series) for name, series in df.items()]
     series_description = {}
 
     if pool_size == 1:

--- a/tests/issues/test_issue537.py
+++ b/tests/issues/test_issue537.py
@@ -114,7 +114,7 @@ def test_multiprocessing_describe1d(config, summarizer, typeset):
 
     def run_multiprocess(config, df):
         pool = multiprocessing.pool.ThreadPool(10)
-        args = [(column, series) for column, series in df.iteritems()]
+        args = [(column, series) for column, series in df.items()]
         results = pool.imap_unordered(
             partial(
                 mock_multiprocess_1d,


### PR DESCRIPTION
... in 1.5.0 (sep 2022), items() available since 0.25 (july 2019)