### PR TITLE
fix: multi thread error on matplotlib default backend

### DIFF
--- a/src/pandas_profiling/visualisation/context.py
+++ b/src/pandas_profiling/visualisation/context.py
@@ -71,6 +71,7 @@ def manage_matplotlib_context() -> Any:
         "ytick.minor.width": 0.5,
         "xtick.major.pad": 7,
         "ytick.major.pad": 7,
+        "backend": "agg",
     }
 
     try:


### PR DESCRIPTION
The following script consistently fails when the multi-threading option is active, entering an infinity loop triggered by matplotlib backend. The fix consists in temporarily changing the backend while creating the plots (ty @fabclmnt for the help with this one).

```python
import pandas as pd
import numpy as np

from pandas_profiling import ProfileReport


def create_dataframes(size=1000, alt=False):
    size = size if not alt else size * 2
    time_steps = np.arange(size)

   df1 =  pd.DataFrame(
        {
            "sin": map(lambda x: round(np.sin(x * np.pi / 180), 2), time_steps),
            "gaussian": map(lambda x: round(x, 2), np.random.normal(0, 1, size)),
        }
    )

    df2 = pd.DataFrame(
        {
            "sin": map(lambda x: round(np.sin(x * np.pi / 180), 2), time_steps),
            "miss2": np.random.choice([0, 1, 2, 3, np.nan], replace=True, size=size),
         }
    )

    return df1, df2


if __name__ == '__main__':
    df1, df2 = create_dataframes()
    prof1 = ProfileReport(df1, title="p1")
    prof2 = ProfileReport(df2, title="p2")
    prof1.to_file("p1.html")
    prof2.to_file("p2.html")
```