### PR TITLE
fix: remove correlation calculation for constants

### DIFF
--- a/tests/issues/test_issue51.py
+++ b/tests/issues/test_issue51.py
@@ -84,7 +84,5 @@ def test_issue51_identical():
         df, title="Pandas Profiling Report", progress_bar=False, explorative=True
     )
     report.config.vars.num.low_categorical_threshold = 0
-
-    assert (
-        report.get_description()["correlations"]["cramers"].values == np.ones((3, 3))
-    ).all()
+    # this should not return any correlation value as the variables are identical constants
+    assert report.get_description()["correlations"] == {}


### PR DESCRIPTION
Pandas profiling returns correlations for constant columns with every other column when calculating 'Auto' and 'Cramers'. This PR ensures these correlations are not calculated.