### PR TITLE
fix(utils): use 'urllib.request' instead of 'requests'

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,1 @@
+titleAndCommits: true

--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -40,7 +40,9 @@ jobs:
       id: version
       run: echo "::set-output name=value::${{ steps.semantic.outputs.new_release_version }}.rc${{ steps.build_number.outputs.value }}"
 
+
   docs-changelog:
+    if: needs.prepare.outputs.new_release == 'true'
     name: Update changelog on docs 
     runs-on: ubuntu-20.04
 
@@ -120,6 +122,7 @@ jobs:
       with:
         tag: ${{ needs.prepare.outputs.version }}
         message: ${{  github.event.head_commit.message }}
+
 
   draft-release:
     if: needs.prepare.outputs.new_release == 'true'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,18 +5,6 @@ on:
   pull_request:
 
 jobs:
-  commitlint:
-    if: github.actor != 'dependabot[bot]'
-    name: Lint commit message
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
-    - uses: wagoid/commitlint-github-action@v5
-
   lint:
     if: github.actor != 'dependabot[bot]'
     name: Lint source code

--- a/src/pandas_profiling/utils/cache.py
+++ b/src/pandas_profiling/utils/cache.py
@@ -2,7 +2,7 @@
 import zipfile
 from pathlib import Path
 
-import requests
+from urllib import request
 
 from pandas_profiling.utils.paths import get_data_path
 
@@ -25,8 +25,8 @@ def cache_file(file_name: str, url: str) -> Path:
 
     # If not exists, download and create file
     if not file_path.exists():
-        response = requests.get(url)
-        file_path.write_bytes(response.content)
+        response = request.urlopen(url)
+        file_path.write_bytes(response.read())
 
     return file_path
 
@@ -49,12 +49,10 @@ def cache_zipped_file(file_name: str, url: str) -> Path:
 
     # If not exists, download and create file
     if not file_path.exists():
-        response = requests.get(url)
-        if response.status_code != 200:
-            raise FileNotFoundError("Could not download resource")
+        response = request.urlopen(url)
 
         tmp_path = data_path / "tmp.zip"
-        tmp_path.write_bytes(response.content)
+        tmp_path.write_bytes(response.read())
 
         with zipfile.ZipFile(tmp_path, "r") as zip_file:
             zip_file.extract(file_path.name, data_path)


### PR DESCRIPTION
`requests` doesn't seem to handle TLS/SSL pretty well. It returns `Forbidden` when we try to get a content from an HTTPS URL such as `https://query1.finance.yahoo.com/v7/finance/download/BABA?period1=1635724800&period2=1667260800&interval=1d&events=history&includeAdjustedClose=true`. That's why we should use `urllib.request` instead.

On the other hand, I need to remove `raise FileNotFoundError("Could not download resource")` as `urllib.request.urlopen` already handle that with its `HTTPError`.