### PR TITLE
 feat: detect timeseries dataset automatically

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,1 @@
+titleAndCommits: true

--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -40,7 +40,9 @@ jobs:
       id: version
       run: echo "::set-output name=value::${{ steps.semantic.outputs.new_release_version }}.rc${{ steps.build_number.outputs.value }}"
 
+
   docs-changelog:
+    if: needs.prepare.outputs.new_release == 'true'
     name: Update changelog on docs 
     runs-on: ubuntu-20.04
 
@@ -120,6 +122,7 @@ jobs:
       with:
         tag: ${{ needs.prepare.outputs.version }}
         message: ${{  github.event.head_commit.message }}
+
 
   draft-release:
     if: needs.prepare.outputs.new_release == 'true'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,18 +5,6 @@ on:
   pull_request:
 
 jobs:
-  commitlint:
-    if: github.actor != 'dependabot[bot]'
-    name: Lint commit message
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
-    - uses: wagoid/commitlint-github-action@v5
-
   lint:
     if: github.actor != 'dependabot[bot]'
     name: Lint source code

--- a/src/pandas_profiling/config.py
+++ b/src/pandas_profiling/config.py
@@ -92,7 +92,7 @@ class UrlVars(BaseModel):
 
 
 class TimeseriesVars(BaseModel):
-    active: bool = False
+    active: Optional[bool] = None
     sortby: Optional[str] = None
     autocorrelation: float = 0.7
     lags: List[int] = [1, 7, 12, 24, 30]

--- a/src/pandas_profiling/config_default.yaml
+++ b/src/pandas_profiling/config_default.yaml
@@ -73,7 +73,7 @@ vars:
     url:
         active: false
     timeseries:
-        active: false
+        active: null
         autocorrelation: 0.7
         lags: [1, 7, 12, 24, 30]
         significance: 0.05

--- a/src/pandas_profiling/config_minimal.yaml
+++ b/src/pandas_profiling/config_minimal.yaml
@@ -74,7 +74,7 @@ vars:
     url:
         active: false
     timeseries:
-        active: false
+        active: null
         autocorrelation: 0.7
         lags: [1, 7, 12, 24, 30]
         significance: 0.05

--- a/src/pandas_profiling/utils/common.py
+++ b/src/pandas_profiling/utils/common.py
@@ -1,6 +1,7 @@
 """Common util functions (e.g. missing in Python)."""
 import collections.abc
 import zipfile
+import re
 from datetime import datetime, timedelta
 
 # Monkeypatch bug in imagehdr
@@ -88,3 +89,9 @@ def convert_timestamp_to_datetime(timestamp: int) -> datetime:
         return datetime.fromtimestamp(timestamp)
     else:
         return datetime(1970, 1, 1) + timedelta(seconds=int(timestamp))
+
+def is_datetime(text: str) -> bool:
+    return re.fullmatch(
+        r"(\d{1,2}[.:]\d{1,2}\s+)?(\d{2,4}[/.\-:]\d{2}[/.\-:]\d{2,4})"
+        r"(\s+\d{1,2}[.:]\d{1,2})?", text
+        ) is not None


### PR DESCRIPTION
**Motivation:**
When I first know this library, I didn't know if it has timeseries mode. I was absolutely beginner in data science.

With this PR, I hope it can give practical output for newcomers, as they might don't know the difference between timeseries dataset and the regular ones.

**Replies for previous PR:**

> The automation will return too many false positives, which is not ideal. Please only activate the evaluation in case it is specifically requested by the user to generate a time-series report.

Thanks for noticing it. `dateutils.parser.parse` indeed matches broad types of string which is prone to false positivity. That's why I changed it to a more visible regex that matches only common datetime formats.

Regarding to false positivity, I already checked it in my notebook: https://colab.research.google.com/drive/1jCQFblAoNWtY2Zp26kwzdGzYvwlr1Mta?usp=sharing

There you can see that the only timeseries dataset is "BABA.csv". You can also try some other timeseries and regular datasets there.

> `tsmode` should not be an optional input. Please keep it as False. This was a requirement when the feature was implemented.

I think it should be fine as we can't always assume that a dataset is non timeseries and the feature is relatively new.