### PR TITLE
fix: only compute auto correlation when no config is specified

### DIFF
--- a/examples/features/correlation_demo.py
+++ b/examples/features/correlation_demo.py
@@ -40,6 +40,16 @@ if __name__ == "__main__":
     # Saving the data profiling report with the 'auto' correlation matrix to a html file
     profile.to_file(Path("auto_uci_bank_marketing_report.html"))
 
+    # The 'Auto' correlation is also the only correlation computed when no configuration
+    # file is specified.
+
+    profile = ProfileReport(
+        df,
+        title="Profile Report of the UCI Bank Marketing Dataset",
+    )
+
+    profile.to_file(Path("auto_no_config_uci_bank_marketing_report.html"))
+
     # The default configuration only computes the 'Auto' correlation.
     # To deactivate this setting and instead calculate other types of correlations such as Pearson's
     # and Cramer's V we can do the following:

--- a/src/pandas_profiling/config.py
+++ b/src/pandas_profiling/config.py
@@ -303,11 +303,6 @@ class Settings(BaseSettings):
 
     correlations: Dict[str, Correlation] = {
         "auto": Correlation(key="auto"),
-        "spearman": Correlation(key="spearman"),
-        "pearson": Correlation(key="pearson"),
-        "kendall": Correlation(key="kendall"),
-        "cramers": Correlation(key="cramers"),
-        "phi_k": Correlation(key="phi_k"),
     }
 
     interactions: Interactions = Interactions()


### PR DESCRIPTION
At the moment auto correlation is the only correlation calculated when specifying config_default.yaml. This fix ensures that the auto correlation is also only calculated when no configuration file is specified.

After these changes the reports appear as the following:

```
profile = ProfileReport(
        df,
        title="Profile Report of the UCI Bank Marketing Dataset",
    )
```
<img width="914" alt="image" src="https://user-images.githubusercontent.com/82936427/204509722-fc529bab-e57e-424b-a8e9-c4676b0db54b.png">

```
no_auto_profile = ProfileReport(
        df,
        title="Profile Report of the UCI Bank Marketing Dataset",
        correlations={
            "auto": {"calculate": False},
            "pearson": {"calculate": True},
            "cramers": {"calculate": True},
        },
    )
```

<img width="639" alt="image" src="https://user-images.githubusercontent.com/82936427/204511035-dd2af65e-1ffa-4cc0-8cb2-09d04cb257a9.png">


```
profile = ProfileReport(
        df,
        title="Profile Report of the UCI Bank Marketing Dataset",
        config_file="src/pandas_profiling/config_default.yaml",
        correlations={
            "auto": {"n_bins": 8},
        },
    )
```

<img width="883" alt="image" src="https://user-images.githubusercontent.com/82936427/204509327-611a09a4-6c18-457f-b32d-f13e3989d2e5.png">


```
no_auto_profile = ProfileReport(
        df,
        title="Profile Report of the UCI Bank Marketing Dataset",
        config_file="src/pandas_profiling/config_default.yaml",
        correlations={
            "auto": {"calculate": False},
            "pearson": {"calculate": True},
            "cramers": {"calculate": True},
        },
    )
```
<img width="587" alt="image" src="https://user-images.githubusercontent.com/82936427/204509951-2fe8d7e6-10c5-4f5b-a731-e2a41c0436ec.png">
