### PR TITLE
fix: categorical data not being obscured in the common values plot

### DIFF
--- a/src/pandas_profiling/visualisation/plot.py
+++ b/src/pandas_profiling/visualisation/plot.py
@@ -342,9 +342,7 @@ def scatter_pairwise(
 
 
 def _plot_stacked_barh(
-    data: pd.Series,
-    colors: List,
-    hide_legend: bool = False
+    data: pd.Series, colors: List, hide_legend: bool = False
 ) -> Tuple[plt.Axes, matplotlib.legend.Legend]:
     """Plot a stacked horizontal bar chart to show category frequency.
     Works for boolean and categorical features.
@@ -403,9 +401,7 @@ def _plot_stacked_barh(
 
 
 def _plot_pie_chart(
-    data: pd.Series,
-    colors: List,
-    hide_legend: bool = False
+    data: pd.Series, colors: List, hide_legend: bool = False
 ) -> Tuple[plt.Axes, matplotlib.legend.Legend]:
     """Plot a pie chart to show category frequency.
     Works for boolean and categorical features.
@@ -485,9 +481,13 @@ def cat_frequency_plot(
     if plot_type == "bar":
         if isinstance(data, list):
             for v in data:
-                plot, legend = _plot_stacked_barh(v, colors, hide_legend=config.vars.cat.redact)
+                plot, legend = _plot_stacked_barh(
+                    v, colors, hide_legend=config.vars.cat.redact
+                )
         else:
-            plot, legend = _plot_stacked_barh(data, colors, hide_legend=config.vars.cat.redact)
+            plot, legend = _plot_stacked_barh(
+                data, colors, hide_legend=config.vars.cat.redact
+            )
 
     elif plot_type == "pie":
         plot, legend = _plot_pie_chart(data, colors, hide_legend=config.vars.cat.redact)

--- a/tests/unit/test_plot.py
+++ b/tests/unit/test_plot.py
@@ -50,9 +50,7 @@ def test_plot_stacked_barh(data, hide_legend):
     default_colors = rcParams["axes.prop_cycle"].by_key()["color"]  # careful max is 10
 
     ax, legend = _plot_stacked_barh(
-        data=data,
-        colors=default_colors[: len(data)],
-        hide_legend=hide_legend
+        data=data, colors=default_colors[: len(data)], hide_legend=hide_legend
     )
     assert issubclass(type(ax), Axes)  # test that a matplotlib plot is returned
     if hide_legend:
@@ -68,9 +66,7 @@ def test_plot_pie_chart(data, hide_legend):
     default_colors = rcParams["axes.prop_cycle"].by_key()["color"]  # careful max is 10
 
     ax, legend = _plot_pie_chart(
-        data=data,
-        colors=default_colors[: len(data)],
-        hide_legend=hide_legend
+        data=data, colors=default_colors[: len(data)], hide_legend=hide_legend
     )
     assert issubclass(type(ax), Axes)  # test that a matplotlib plot is returned
     if hide_legend:


### PR DESCRIPTION
When using the flag `sensitive=True`, the Common Values plot was still displaying the legends with all the categories (for both bar and pie charts). The legends are now hidden when this flag is active (see the images below). The unit tests were updated to cover the new code changes. All unit tests passed. 

![Screenshot from 2022-11-30 22-39-02](https://user-images.githubusercontent.com/21283729/204924454-d16648f2-ee6b-4b77-8f67-0e08f8190b62.png)

![Screenshot from 2022-11-30 22-39-30](https://user-images.githubusercontent.com/21283729/204924466-bfa18035-6fb6-4d0b-a97a-86d664cecc91.png)