### PR TITLE
feat: allow to specify the configuration for the comparison report

### DIFF
--- a/src/pandas_profiling/compare_reports.py
+++ b/src/pandas_profiling/compare_reports.py
@@ -129,7 +129,9 @@ def _compare_profile_report_preprocess(
     else:
         if len(config.html.style.primary_colors) > 1:
             for idx, report in enumerate(reports):
-                report.config.html.style.primary_colors = config.html.style.primary_colors
+                report.config.html.style.primary_colors = (
+                    config.html.style.primary_colors
+                )
 
     # Obtain description sets
     descriptions = [report.get_description() for report in reports]

--- a/src/pandas_profiling/profile_report.py
+++ b/src/pandas_profiling/profile_report.py
@@ -473,7 +473,9 @@ class ProfileReport(SerializeReport, ExpectationsReport):
         """Override so that Jupyter Notebook does not print the object."""
         return ""
 
-    def compare(self, other: "ProfileReport", config: Optional[Settings] = None) -> "ProfileReport":
+    def compare(
+        self, other: "ProfileReport", config: Optional[Settings] = None
+    ) -> "ProfileReport":
         """Compare this report with another ProfileReport
         Alias for:
         ```


### PR DESCRIPTION
Until now it was not possible to specify the configuration to use for the comparison report and it would use the default one which my not be suitable (e.g. if values needs to be hidden).

Build a report with a particular configuration (no nav bar)
![image](https://user-images.githubusercontent.com/1913007/205033529-5c179e53-188a-45f9-a82b-6a484f716b77.png)

Compare to a second report: by default is now as the same config as the original report:
![image](https://user-images.githubusercontent.com/1913007/205035895-75103506-e771-441c-8f70-6090cd7136d9.png)

But if I want my comparison report to have a particular config, I can specify it (in this case, the nav bar is back):
![image](https://user-images.githubusercontent.com/1913007/205034163-71597067-5fc1-4196-878d-36eea297f5da.png)

