### PR TITLE
fix: do no raise exception for percentage formatter

### DIFF
--- a/src/pandas_profiling/report/formatters.py
+++ b/src/pandas_profiling/report/formatters.py
@@ -85,8 +85,6 @@ def fmt_percent(value: float, edge_cases: bool = True) -> str:
     Returns:
         The percentage with 1 point precision.
     """
-    if not (1.0 >= value >= 0.0):
-        raise ValueError(f"Value '{value}' should be a ratio between 1 and 0.")
     if edge_cases and round(value, 3) == 0 and value > 0:
         return "< 0.1%"
     if edge_cases and round(value, 3) == 1 and value < 1:

--- a/tests/issues/test_issue215.py
+++ b/tests/issues/test_issue215.py
@@ -19,9 +19,3 @@ from pandas_profiling.report.formatters import fmt_percent
 )
 def test_issue215(ratio, expected_formatting):
     assert fmt_percent(ratio) == expected_formatting
-
-
-@pytest.mark.parametrize("ratio", [100, 1.2])
-def test_issue215_exception(ratio):
-    with pytest.raises(ValueError):
-        fmt_percent(ratio)


### PR DESCRIPTION
A percentage might be higher than 100% when it expresses a ratio for instance.
We should not control this behavior at the formatter level.