### PR TITLE
feat: add heatmap values as a table under correlations

### DIFF
--- a/src/pandas_profiling/config.py
+++ b/src/pandas_profiling/config.py
@@ -305,6 +305,8 @@ class Settings(BaseSettings):
         "auto": Correlation(key="auto"),
     }
 
+    correlation_table: bool = True
+
     interactions: Interactions = Interactions()
 
     categorical_maximum_correlation_distinct: int = 100
@@ -394,6 +396,7 @@ class Config:
             "phi_k": {"calculate": False},
             "cramers": {"calculate": False},
         },
+        "correlation_table": True,
     }
 
     @staticmethod

--- a/src/pandas_profiling/report/formatters.py
+++ b/src/pandas_profiling/report/formatters.py
@@ -85,8 +85,6 @@ def fmt_percent(value: float, edge_cases: bool = True) -> str:
     Returns:
         The percentage with 1 point precision.
     """
-    if not (1.0 >= value >= 0.0):
-        raise ValueError(f"Value '{value}' should be a ratio between 1 and 0.")
     if edge_cases and round(value, 3) == 0 and value > 0:
         return "< 0.1%"
     if edge_cases and round(value, 3) == 1 and value < 1:

--- a/src/pandas_profiling/report/presentation/core/__init__.py
+++ b/src/pandas_profiling/report/presentation/core/__init__.py
@@ -1,6 +1,7 @@
 from pandas_profiling.report.presentation.core.alerts import Alerts
 from pandas_profiling.report.presentation.core.collapse import Collapse
 from pandas_profiling.report.presentation.core.container import Container
+from pandas_profiling.report.presentation.core.correlation_table import CorrelationTable
 from pandas_profiling.report.presentation.core.dropdown import Dropdown
 from pandas_profiling.report.presentation.core.duplicate import Duplicate
 from pandas_profiling.report.presentation.core.frequency_table import FrequencyTable
@@ -32,4 +33,5 @@ __all__ = [
     "Variable",
     "VariableInfo",
     "Alerts",
+    "CorrelationTable",
 ]

--- a/src/pandas_profiling/report/presentation/core/correlation_table.py
+++ b/src/pandas_profiling/report/presentation/core/correlation_table.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+import pandas as pd
+
+from pandas_profiling.report.presentation.core.item_renderer import ItemRenderer
+
+
+class CorrelationTable(ItemRenderer):
+    def __init__(self, name: str, correlation_matrix: pd.DataFrame, **kwargs):
+        super().__init__(
+            "correlation_table",
+            {"correlation_matrix": correlation_matrix},
+            name=name,
+            **kwargs
+        )
+
+    def __repr__(self) -> str:
+        return "CorrelationTable"
+
+    def render(self) -> Any:
+        raise NotImplementedError()

--- a/src/pandas_profiling/report/presentation/flavours/flavours.py
+++ b/src/pandas_profiling/report/presentation/flavours/flavours.py
@@ -23,6 +23,7 @@ def get_html_renderable_mapping() -> Dict[Type[Renderable], Type[Renderable]]:
         Alerts,
         Collapse,
         Container,
+        CorrelationTable,
         Dropdown,
         Duplicate,
         FrequencyTable,
@@ -40,6 +41,7 @@ def get_html_renderable_mapping() -> Dict[Type[Renderable], Type[Renderable]]:
         HTMLAlerts,
         HTMLCollapse,
         HTMLContainer,
+        HTMLCorrelationTable,
         HTMLDropdown,
         HTMLDuplicate,
         HTMLFrequencyTable,
@@ -69,6 +71,7 @@ def get_html_renderable_mapping() -> Dict[Type[Renderable], Type[Renderable]]:
         Sample: HTMLSample,
         ToggleButton: HTMLToggleButton,
         Collapse: HTMLCollapse,
+        CorrelationTable: HTMLCorrelationTable,
     }
 
 
@@ -92,6 +95,7 @@ def get_widget_renderable_mapping() -> Dict[Type[Renderable], Type[Renderable]]:
         Alerts,
         Collapse,
         Container,
+        CorrelationTable,
         Dropdown,
         Duplicate,
         FrequencyTable,
@@ -108,6 +112,7 @@ def get_widget_renderable_mapping() -> Dict[Type[Renderable], Type[Renderable]]:
         WidgetAlerts,
         WidgetCollapse,
         WidgetContainer,
+        WidgetCorrelationTable,
         WidgetDropdown,
         WidgetDuplicate,
         WidgetFrequencyTable,
@@ -138,6 +143,7 @@ def get_widget_renderable_mapping() -> Dict[Type[Renderable], Type[Renderable]]:
         Sample: WidgetSample,
         ToggleButton: WidgetToggleButton,
         Collapse: WidgetCollapse,
+        CorrelationTable: WidgetCorrelationTable,
     }
 
 

--- a/src/pandas_profiling/report/presentation/flavours/html/__init__.py
+++ b/src/pandas_profiling/report/presentation/flavours/html/__init__.py
@@ -1,6 +1,9 @@
 from pandas_profiling.report.presentation.flavours.html.alerts import HTMLAlerts
 from pandas_profiling.report.presentation.flavours.html.collapse import HTMLCollapse
 from pandas_profiling.report.presentation.flavours.html.container import HTMLContainer
+from pandas_profiling.report.presentation.flavours.html.correlation_table import (
+    HTMLCorrelationTable,
+)
 from pandas_profiling.report.presentation.flavours.html.dropdown import HTMLDropdown
 from pandas_profiling.report.presentation.flavours.html.duplicate import HTMLDuplicate
 from pandas_profiling.report.presentation.flavours.html.frequency_table import (
@@ -38,4 +41,5 @@ __all__ = [
     "HTMLVariable",
     "HTMLVariableInfo",
     "HTMLAlerts",
+    "HTMLCorrelationTable",
 ]

--- a/src/pandas_profiling/report/presentation/flavours/html/correlation_table.py
+++ b/src/pandas_profiling/report/presentation/flavours/html/correlation_table.py
@@ -5,7 +5,8 @@ from pandas_profiling.report.presentation.flavours.html import templates
 class HTMLCorrelationTable(CorrelationTable):
     def render(self) -> str:
         correlation_matrix_html = self.content["correlation_matrix"].to_html(
-            classes="correlation-table table table-striped", float_format="{:.3f}".format
+            classes="correlation-table table table-striped",
+            float_format="{:.3f}".format,
         )
         return templates.template("correlation_table.html").render(
             **self.content, correlation_matrix_html=correlation_matrix_html

--- a/src/pandas_profiling/report/presentation/flavours/html/correlation_table.py
+++ b/src/pandas_profiling/report/presentation/flavours/html/correlation_table.py
@@ -1,0 +1,12 @@
+from pandas_profiling.report.presentation.core.correlation_table import CorrelationTable
+from pandas_profiling.report.presentation.flavours.html import templates
+
+
+class HTMLCorrelationTable(CorrelationTable):
+    def render(self) -> str:
+        correlation_matrix_html = self.content["correlation_matrix"].to_html(
+            classes="correlation-table table table-striped", float_format="{:.3f}".format
+        )
+        return templates.template("correlation_table.html").render(
+            **self.content, correlation_matrix_html=correlation_matrix_html
+        )

--- a/src/pandas_profiling/report/presentation/flavours/html/templates/correlation_table.html
+++ b/src/pandas_profiling/report/presentation/flavours/html/templates/correlation_table.html
@@ -1,0 +1,3 @@
+<div id="correlation-table-container" class="col-sm-12">
+    {{ correlation_matrix_html }}
+</div>

--- a/src/pandas_profiling/report/presentation/flavours/html/templates/wrapper/assets/style.css
+++ b/src/pandas_profiling/report/presentation/flavours/html/templates/wrapper/assets/style.css
@@ -18,7 +18,7 @@ body {
     border-top: hidden;
 }
 
-.row.spacing{
+.row.spacing {
     padding: 2em 1em;
 }
 
@@ -71,12 +71,16 @@ table.example_values {
     color: #555;
 }
 
+table.correlation-table {
+    width: 98%  /* To avoid an unnecessary overflow. */
+}
+
 /* STATS */
-table.stats, table.sample, table.duplicate{
+table.stats, table.sample, table.duplicate, table.correlation-table{
     border: 0;
 }
 
-.stats tr, .sample tr, .duplicate tr {
+.stats tr, .sample tr, .duplicate tr, .correlation-table tr {
     border: 0;
 }
 
@@ -96,27 +100,26 @@ table.stats, table.sample, table.duplicate{
 
 
 /* Sample table */
-table.sample, table.duplicate{
+table.sample, table.duplicate, table.correlation-table {
     margin-bottom: 2em;
     margin-left: 1em;
 }
 
-.sample td, .sample th, .duplicate td, .duplicate th {
+.sample td, .sample th, .duplicate td, .duplicate th, .correlation-table td, .correlation-table th {
     padding: 0.5em;
     white-space: nowrap;
     border: 0;
 
 }
 
-.sample thead, .duplicate thead {
+.sample thead, .duplicate thead, .correlation-table thead {
     border-top: 0;
     border-bottom: 2px solid #ddd;
 }
 
 .sample td, .duplicate td {
     width: 100%;
-}
-
+} 
 
 /* There is no good solution available to make the divs equal height and then center ... */
 .histogram {
@@ -246,6 +249,7 @@ table.freq.mini {
 }
 .img-responsive{
     max-width: 99%;
+    min-width: 99%;
 }
 .footer-text{
     padding:20px;
@@ -266,10 +270,15 @@ a.anchor-pos-variable{
     /*top: -70px;*/
 }
 
-#sample-container, #duplicate-container{
+#sample-container, #duplicate-container {
     overflow: auto;
     width: 100%;
     overflow-y: hidden;
+}
+
+#correlation-table-container {
+    max-height: 400px;
+    overflow: auto;
 }
 
 #overview-content td, #overview-content th{

--- a/src/pandas_profiling/report/presentation/flavours/widget/__init__.py
+++ b/src/pandas_profiling/report/presentation/flavours/widget/__init__.py
@@ -3,6 +3,9 @@ from pandas_profiling.report.presentation.flavours.widget.collapse import Widget
 from pandas_profiling.report.presentation.flavours.widget.container import (
     WidgetContainer,
 )
+from pandas_profiling.report.presentation.flavours.widget.correlation_table import (
+    WidgetCorrelationTable,
+)
 from pandas_profiling.report.presentation.flavours.widget.dropdown import WidgetDropdown
 from pandas_profiling.report.presentation.flavours.widget.duplicate import (
     WidgetDuplicate,
@@ -42,4 +45,5 @@ __all__ = [
     "WidgetVariable",
     "WidgetVariableInfo",
     "WidgetAlerts",
+    "WidgetCorrelationTable",
 ]

--- a/src/pandas_profiling/report/presentation/flavours/widget/correlation_table.py
+++ b/src/pandas_profiling/report/presentation/flavours/widget/correlation_table.py
@@ -1,0 +1,14 @@
+from IPython.core.display import display
+from ipywidgets import Output, widgets
+
+from pandas_profiling.report.presentation.core.correlation_table import CorrelationTable
+
+
+class WidgetCorrelationTable(CorrelationTable):
+    def render(self) -> widgets.VBox:
+        out = Output()
+        with out:
+            display(self.content["correlation_matrix"])
+
+        name = widgets.HTML(f"<h4>{self.content['name']}</h4>")
+        return widgets.VBox([name, out])

--- a/src/pandas_profiling/report/structure/correlations.py
+++ b/src/pandas_profiling/report/structure/correlations.py
@@ -1,11 +1,7 @@
 from typing import List, Optional
 
 from pandas_profiling.config import Settings
-from pandas_profiling.report.presentation.core import (
-    Container,
-    CorrelationTable,
-    Image,
-)
+from pandas_profiling.report.presentation.core import Container, CorrelationTable, Image
 from pandas_profiling.report.presentation.core.renderable import Renderable
 from pandas_profiling.visualisation import plot
 

--- a/src/pandas_profiling/report/structure/overview.py
+++ b/src/pandas_profiling/report/structure/overview.py
@@ -228,8 +228,9 @@ def get_dataset_alerts(config: Settings, alerts: list) -> Alerts:
 
         # Initialize
         combined_alerts = {
-            f"{alert.alert_type}_{alert.column_name}": 
-                [None for _ in range(len(alerts))]
+            f"{alert.alert_type}_{alert.column_name}": [
+                None for _ in range(len(alerts))
+            ]
             for report_alerts in alerts
             for alert in report_alerts
         }
@@ -247,7 +248,7 @@ def get_dataset_alerts(config: Settings, alerts: list) -> Alerts:
                     if alert.alert_type != AlertType.REJECTED
                 ]
             )
-        
+
         return Alerts(
             alerts=combined_alerts,
             name=f"Alerts ({count})",

--- a/src/pandas_profiling/report/structure/overview.py
+++ b/src/pandas_profiling/report/structure/overview.py
@@ -227,9 +227,9 @@ def get_dataset_alerts(config: Settings, alerts: list) -> Alerts:
         count = 0
 
         # Initialize
-        no_alerts = [None for _ in range(len(alerts))]
         combined_alerts = {
-            f"{alert.alert_type}_{alert.column_name}": no_alerts
+            f"{alert.alert_type}_{alert.column_name}": 
+                [None for _ in range(len(alerts))]
             for report_alerts in alerts
             for alert in report_alerts
         }
@@ -247,7 +247,7 @@ def get_dataset_alerts(config: Settings, alerts: list) -> Alerts:
                     if alert.alert_type != AlertType.REJECTED
                 ]
             )
-
+        
         return Alerts(
             alerts=combined_alerts,
             name=f"Alerts ({count})",

--- a/tests/issues/test_issue215.py
+++ b/tests/issues/test_issue215.py
@@ -19,9 +19,3 @@ from pandas_profiling.report.formatters import fmt_percent
 )
 def test_issue215(ratio, expected_formatting):
     assert fmt_percent(ratio) == expected_formatting
-
-
-@pytest.mark.parametrize("ratio", [100, 1.2])
-def test_issue215_exception(ratio):
-    with pytest.raises(ValueError):
-        fmt_percent(ratio)

--- a/tests/unit/test_correlations.py
+++ b/tests/unit/test_correlations.py
@@ -1,0 +1,83 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from pandas_profiling import ProfileReport
+from pandas_profiling.report.presentation.core import HTML, CorrelationTable, Image
+from pandas_profiling.report.structure.correlations import get_correlation_items
+
+
+@pytest.mark.skip
+def generate_df(n: int):
+    return pd.DataFrame(
+        {
+            "num_int": np.random.randint(0, 20, n),
+            "num_float": 100 * np.random.normal(0, 0.1, n),
+            "cat_str": np.random.choice(
+                a=["CAT_A", "CAT_B", "CAT_C"], size=n, p=[0.5, 0.3, 0.2]
+            ),
+            "cat_int": np.random.choice(
+                a=[1, 2, 5, 10], size=n, p=[0.4, 0.3, 0.2, 0.1]
+            ),
+        }
+    )
+
+
+@pytest.mark.skip
+def generate_report(correlation_table: bool):
+    df = generate_df(300)
+
+    correlations = {
+        "auto": {"calculate": True},
+        "pearson": {"calculate": True},
+        "spearman": {"calculate": True},
+        "kendall": {"calculate": True},
+        "phi_k": {"calculate": True},
+        "cramers": {"calculate": True},
+    }
+
+    return ProfileReport(
+        df,
+        title="Profiling Report",
+        correlations=correlations,
+        correlation_table=correlation_table,
+    )
+
+
+def test_standard_report_with_correlation_table():
+    report = generate_report(correlation_table=True)
+    renderable = get_correlation_items(report.config, report.description_set)
+    for cor_item in renderable.content["items"]:
+        diagram, table = cor_item.content["items"]
+        assert isinstance(table, CorrelationTable)
+        assert isinstance(diagram, Image)
+
+
+def test_standard_report_without_correlation_table():
+    report = generate_report(correlation_table=False)
+    renderable = get_correlation_items(report.config, report.description_set)
+    for diagram in renderable.content["items"]:
+        assert isinstance(diagram, Image)
+
+
+def test_compare_report_with_correlation_table():
+    report1 = generate_report(correlation_table=True)
+    report2 = generate_report(correlation_table=True)
+    comp_report = report1.compare(report2)
+    renderable = get_correlation_items(comp_report.config, comp_report.description_set)
+    for cor_items in renderable.content["items"]:
+        diagrams, tables = cor_items.content["items"]
+        for table in tables.content["items"]:
+            assert isinstance(table, CorrelationTable)
+        for diagram in diagrams.content["items"]:
+            assert isinstance(diagram, Image)
+
+
+def test_compare_report_without_correlation_table():
+    report1 = generate_report(correlation_table=False)
+    report2 = generate_report(correlation_table=False)
+    comp_report = report1.compare(report2)
+    renderable = get_correlation_items(comp_report.config, comp_report.description_set)
+    for cor_items in renderable.content["items"]:
+        for diagram in cor_items.content["items"]:
+            assert isinstance(diagram, Image)


### PR DESCRIPTION
- For each correlation, we now have the option to display the data as a heatmap and as a table (see the 2 images below). By default, both visualizations are displayed. To only show the heatmaps, set `correlation_table=False`.

![Screenshot from 2022-12-07 10-44-41](https://user-images.githubusercontent.com/21283729/206161012-22568661-dc8d-4412-89be-df6616d5e083.png)
![Screenshot from 2022-12-07 10-45-02](https://user-images.githubusercontent.com/21283729/206161059-20de2978-cb31-4d42-8b0c-caf4a44310b5.png)

- This feature was also added to the compare reports (see the 2 images below).

![Screenshot from 2022-12-07 10-45-20](https://user-images.githubusercontent.com/21283729/206161204-bc4f784e-624b-4867-879a-50d04b4d9967.png)
![Screenshot from 2022-12-07 10-45-27](https://user-images.githubusercontent.com/21283729/206161242-435c8007-a77b-4959-b378-55d37d97d92e.png)

- New unit tests were added to the correlation rendering components. All unit tests passed.

