### PR TITLE
fix: compare report warnings always showing the last alert type

### DIFF
--- a/src/pandas_profiling/report/structure/overview.py
+++ b/src/pandas_profiling/report/structure/overview.py
@@ -227,9 +227,9 @@ def get_dataset_alerts(config: Settings, alerts: list) -> Alerts:
         count = 0
 
         # Initialize
-        no_alerts = [None for _ in range(len(alerts))]
         combined_alerts = {
-            f"{alert.alert_type}_{alert.column_name}": no_alerts
+            f"{alert.alert_type}_{alert.column_name}": 
+                [None for _ in range(len(alerts))]
             for report_alerts in alerts
             for alert in report_alerts
         }
@@ -247,7 +247,7 @@ def get_dataset_alerts(config: Settings, alerts: list) -> Alerts:
                     if alert.alert_type != AlertType.REJECTED
                 ]
             )
-
+        
         return Alerts(
             alerts=combined_alerts,
             name=f"Alerts ({count})",


### PR DESCRIPTION
The initialization of the dictionary used to save the alerts was reusing the same list for every alert type. Since this was a shared reference, the code was updating the same list for all alert types (therefore only keeping the last alert type). The issue is solved (see the image below). All unit tests passed.

![Screenshot from 2022-12-06 14-56-23](https://user-images.githubusercontent.com/21283729/205948284-8b4e084b-1204-4079-9e01-97ba617520a4.png)

