### PR TITLE
fix: comparison fails when duplicates are disable

### DIFF
--- a/src/pandas_profiling/config.py
+++ b/src/pandas_profiling/config.py
@@ -1,6 +1,7 @@
 """Configuration for the package."""
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import yaml
 from pydantic import BaseModel, BaseSettings, Field, PrivateAttr
@@ -336,7 +337,7 @@ class Settings(BaseSettings):
         return self.parse_obj(self.copy(update=update))
 
     @staticmethod
-    def from_file(config_file: str) -> "Settings":
+    def from_file(config_file: Union[Path, str]) -> "Settings":
         """Create a Settings object from a yaml file.
 
         Args:

--- a/src/pandas_profiling/report/structure/report.py
+++ b/src/pandas_profiling/report/structure/report.py
@@ -197,6 +197,9 @@ def get_duplicates_items(
     items: List[Renderable] = []
     if duplicates is not None and len(duplicates) > 0:
         if isinstance(duplicates, list):
+            if any([d is None for d in duplicates]):
+                return items
+
             for idx, df in enumerate(duplicates):
                 items.append(
                     Duplicate(


### PR DESCRIPTION
fix a bug where disabling duplicates leads to the comparison report trying to render an inexistent data frame