### PR TITLE
fix: error comparing reports with pre-computed description_set

### DIFF
--- a/src/pandas_profiling/compare_reports.py
+++ b/src/pandas_profiling/compare_reports.py
@@ -223,7 +223,7 @@ def _apply_config(description: dict, config: Settings) -> dict:
 def compare(
     reports: List[ProfileReport],
     config: Optional[Settings] = None,
-    compute: bool = True,
+    compute: bool = False,
 ) -> ProfileReport:
     """
     Compare Profile reports
@@ -233,6 +233,7 @@ def compare(
                  input may either be a ProfileReport, or the summary obtained from report.get_description()
         config: the settings object for the merged ProfileReport
         compute: recompute the profile report using config or the left report config
+                 recommended in cases where the reports were created using different settings
 
     """
     validate_reports(reports)

--- a/src/pandas_profiling/compare_reports.py
+++ b/src/pandas_profiling/compare_reports.py
@@ -223,6 +223,7 @@ def _apply_config(description: dict, config: Settings) -> dict:
 def compare(
     reports: List[ProfileReport],
     config: Optional[Settings] = None,
+    compute: bool = True,
 ) -> ProfileReport:
     """
     Compare Profile reports
@@ -231,6 +232,7 @@ def compare(
         reports: two reports to compare
                  input may either be a ProfileReport, or the summary obtained from report.get_description()
         config: the settings object for the merged ProfileReport
+        compute: recompute the profile report using config or the left report config
 
     """
     validate_reports(reports)
@@ -243,7 +245,7 @@ def compare(
         return reports[0]
 
     if config is None:
-        _config = Settings()
+        _config = reports[0].config.copy()
     else:
         _config = config.copy()
         for report in reports:
@@ -252,6 +254,8 @@ def compare(
             report.config = config.copy()
             report.config.title = title
             report.config.vars.timeseries.active = tsmode
+            if compute:
+                report._description_set = None
 
     if all(isinstance(report, ProfileReport) for report in reports):
         # Type ignore is needed as mypy does not pick up on the type narrowing


### PR DESCRIPTION
When one of the ProfileReports where already pre-computed (either using lazy=False, persisting the report, or anything that triggers profile.get_description()) could cause errors when the profiles were created using a different configuration. This lead to errors when comparing sessions (e.g. duplicates) of the report that were disabled in only one of the reports.

Added a parameter to enforce the reports to be computed with the same configuration. 
This parameter is only necessary when at least ProfileReport was already calculated and the ProfileReports have different settings.

e.g. 
```python
p1 = ProfileReport(data)
p2 = ProfileReport(data, lazy=False, minimal=True)
# needs to recompute the p2 for comparison
p1.compare(p2, compute=True)
```