### PR TITLE
fix: cat frequency var plot

### DIFF
--- a/src/pandas_profiling/report/presentation/flavours/html/templates/wrapper/assets/style.css
+++ b/src/pandas_profiling/report/presentation/flavours/html/templates/wrapper/assets/style.css
@@ -344,11 +344,6 @@ select.multiple{
 {% endfor %}
 {% if style._labels | length > 1 %}
     /* Report comparison */
-    /* Mini frequency table */
-    table.freq.mini{
-        width:{{ 100 / (style._labels | length) }}%;
-        float:left;
-    }
     /* Full-sized frequency table */
     table.freq:not(.mini){
         width:{{ 90 / (style._labels | length) }}%;


### PR DESCRIPTION
remove from `style.css` code was designed to display the frequency table horizontally instead of vertically:

old:
![image](https://user-images.githubusercontent.com/9274404/208951453-ecbfbebb-be86-4258-863e-7d660765a71d.png)

new:
![image](https://user-images.githubusercontent.com/9274404/208951176-87f8900b-bbc9-489e-b138-8573b30aad1b.png)
