### PR TITLE
fix: comparison histogram

### DIFF
--- a/src/pandas_profiling/visualisation/plot.py
+++ b/src/pandas_profiling/visualisation/plot.py
@@ -118,9 +118,7 @@ def histogram(
       The resulting histogram encoded as a string.
 
     """
-    plot = _plot_histogram(
-        config, series, bins, date=date, figsize=(7, 3)
-    )
+    plot = _plot_histogram(config, series, bins, date=date, figsize=(7, 3))
     plot.xaxis.set_tick_params(rotation=90 if date else 45)
     plot.figure.tight_layout()
     return plot_360_n0sc0pe(config)


### PR DESCRIPTION
It was hard to compare the histograms without an explicit scale, so the histograms were change to display it in the same plot
![image](https://user-images.githubusercontent.com/9274404/209995399-f0de0297-da1b-4207-b9c1-bb263ed612fa.png)
