### PR TITLE
fix: comparison alerts

### DIFF
--- a/src/pandas_profiling/compare_reports.py
+++ b/src/pandas_profiling/compare_reports.py
@@ -229,12 +229,14 @@ def _is_alert_present(alert, alert_list):
 
 def _create_placehoder_alerts(report_alerts: tuple) -> tuple:
     from copy import copy
+
     fixed = [[] for _ in report_alerts]
     for idx, alerts in enumerate(report_alerts):
         for alert in alerts:
             fixed[idx].append(alert)
             for i, fix in enumerate(fixed):
-                if i == idx: continue
+                if i == idx:
+                    continue
                 if not _is_alert_present(alert, report_alerts[i]):
                     empty_alert = copy(alert)
                     empty_alert._is_empty = True

--- a/src/pandas_profiling/compare_reports.py
+++ b/src/pandas_profiling/compare_reports.py
@@ -220,6 +220,28 @@ def _apply_config(description: dict, config: Settings) -> dict:
     return description
 
 
+def _is_alert_present(alert, alert_list):
+    for a in alert_list:
+        if a.column_name == alert.column_name and a.alert_type == alert.alert_type:
+            return True
+    return False
+
+
+def _create_placehoder_alerts(report_alerts: tuple) -> tuple:
+    from copy import copy
+    fixed = [[] for _ in report_alerts]
+    for idx, alerts in enumerate(report_alerts):
+        for alert in alerts:
+            fixed[idx].append(alert)
+            for i, fix in enumerate(fixed):
+                if i == idx: continue
+                if not _is_alert_present(alert, report_alerts[i]):
+                    empty_alert = copy(alert)
+                    empty_alert._is_empty = True
+                    fix.append(empty_alert)
+    return tuple(fixed)
+
+
 def compare(
     reports: List[ProfileReport],
     config: Optional[Settings] = None,
@@ -279,7 +301,7 @@ def compare(
         res = _update_merge(res, r)
 
     res["analysis"]["title"] = _compare_title(res["analysis"]["title"])
-
+    res["alerts"] = _create_placehoder_alerts(res["alerts"])
     profile = ProfileReport(None, config=_config)
     profile._description_set = res
     return profile

--- a/src/pandas_profiling/model/alerts.py
+++ b/src/pandas_profiling/model/alerts.py
@@ -80,6 +80,7 @@ class Alert:
         values: Optional[Dict] = None,
         column_name: Optional[str] = None,
         fields: Optional[Set] = None,
+        is_empty: bool = False,
     ):
         if values is None:
             values = {}
@@ -90,6 +91,7 @@ class Alert:
         self.alert_type = alert_type
         self.values = values
         self.column_name = column_name
+        self._is_empty = is_empty
 
     @property
     def alert_type_name(self) -> str:

--- a/src/pandas_profiling/report/presentation/flavours/html/templates/alerts.html
+++ b/src/pandas_profiling/report/presentation/flavours/html/templates/alerts.html
@@ -16,7 +16,7 @@
                     <tr{% if loop.first %} style="border-top:0"{% endif %}>
                         {% for alert in value %}
                             <td>
-                                {% if alert is not none %}
+                                {% if not alert._is_empty %}
                                     {% include 'alerts/alert_' + alert.alert_type.name | lower  + '.html'  %}
                                 {% else %}
                                     <em>Alert not present in {{ style._labels[idx] }}</em>


### PR DESCRIPTION
Fix the error: 
```jinja2.exceptions.UndefinedError: 'None' has no attribute 'alert_type'```
This error is triggered when comparing datasets that don't have the same set of alerts.