### PR TITLE
Update correlations.py

### DIFF
--- a/src/pandas_profiling/model/correlations.py
+++ b/src/pandas_profiling/model/correlations.py
@@ -12,7 +12,10 @@ from pandas_profiling.utils.compat import pandas_version_info
 if pandas_version_info() >= (1, 5):
     from pandas.errors import DataError
 else:
-    from pandas.core.base import DataError
+    try:
+        from pandas.core.base import DataError
+    except:
+        from pandas.errors import DataError
 
 
 class Correlation:


### PR DESCRIPTION
### attempt to fix: cannot import name 'DataError' from 'pandas.core.base'

- successfully able to run `from pandas.errors import DataError` in Python 3.11.x
   - used try/except to avoid introducing issues for other Python ver