### PR TITLE
fix: time series vars being excluded from correlation and  interaction plots

### DIFF
--- a/src/pandas_profiling/model/describe.py
+++ b/src/pandas_profiling/model/describe.py
@@ -84,7 +84,9 @@ def describe(
             if type_name != "Unsupported"
         ]
         interval_columns = [
-            column for column, type_name in variables.items() if type_name == "Numeric"
+            column
+            for column, type_name in variables.items()
+            if type_name in {"Numeric", "TimeSeries"}
         ]
         pbar.update()
 

--- a/src/pandas_profiling/model/pandas/correlations_pandas.py
+++ b/src/pandas_profiling/model/pandas/correlations_pandas.py
@@ -164,7 +164,7 @@ def pandas_auto_compute(
     numerical_columns = [
         key
         for key, value in summary.items()
-        if value["type"] == "Numeric" and value["n_distinct"] > 1
+        if value["type"] in {"Numeric", "TimeSeries"} and value["n_distinct"] > 1
     ]
     categorical_columns = [
         key


### PR DESCRIPTION
The `Auto` correlation and the interaction plots filter the numeric variables prior to creating the plots, this was filtering out the TimeSeries vars, which are also numeric.